### PR TITLE
Upgrade to singer-python 3.2.0 for $ref changes

### DIFF
--- a/refresh_credentials.py
+++ b/refresh_credentials.py
@@ -1,18 +1,23 @@
 #!/usr/bin/env python3
 from xero.auth import PartnerCredentials
+from xero.exceptions import XeroUnauthorized
 import json
 
 with open("config.json") as f:
     config = json.loads(f.read())
 
-if "oauth_token" not in config:
+
+def new_token():
     credentials = PartnerCredentials(config["consumer_key"],
                                      config["consumer_secret"],
                                      config["rsa_key"])
     print(credentials.url)
     verifier = input("verifier: ")
     credentials.verify(verifier)
-else:
+    return credentials
+
+
+def refreshed_token():
     credentials = PartnerCredentials(
         config["consumer_key"],
         config["consumer_secret"],
@@ -23,6 +28,15 @@ else:
         oauth_session_handle=config["oauth_session_handle"],
     )
     credentials.refresh()
+    return credentials
+
+if "oauth_token" not in config:
+    credentials = new_token()
+else:
+    try:
+        credentials = refreshed_token()
+    except XeroUnauthorized:
+        credentials = new_token()
 
 state = credentials.state
 for k in ["oauth_expires_at", "oauth_authorization_expires_at", "verified"]:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 nose
 mock
 singer-tools
-target-stitch>=0.10.1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,9 @@ setup(name="tap-xero",
       classifiers=["Programming Language :: Python :: 3 :: Only"],
       py_modules=["tap_xero"],
       install_requires=[
-          "singer-python==2.1.4",
+          "python-dateutil==2.6.0",  # This is required by singer-python,
+          # without this being here explicitly, there are dependency issues
+          "singer-python>=3.2.0",
           "pyxero<1",
           "requests",
           "attrs",

--- a/tap_xero/__init__.py
+++ b/tap_xero/__init__.py
@@ -82,13 +82,12 @@ def get_abs_path(path):
 def load_schema(tap_stream_id):
     path = "schemas/{}.json".format(tap_stream_id)
     schema = utils.load_json(get_abs_path(path))
-    if "definitions" not in schema:
-        schema["definitions"] = {}
-    for sub_stream_id in list(schema["definitions"].keys()):
-        sub_schema = load_schema(sub_stream_id)
-        schema["definitions"][sub_stream_id] = sub_schema
-        if "definitions" in sub_schema:
-            schema["definitions"].update(sub_schema.pop("definitions"))
+    dependencies = schema.pop("tap_xero_schema_dependencies", [])
+    refs = {}
+    for sub_stream_id in dependencies:
+        refs[sub_stream_id] = load_schema(sub_stream_id)
+    if refs:
+        singer.resolve_schema_references(schema, refs)
     return schema
 
 

--- a/tap_xero/__init__.py
+++ b/tap_xero/__init__.py
@@ -82,7 +82,7 @@ def get_abs_path(path):
 def load_schema(tap_stream_id):
     path = "schemas/{}.json".format(tap_stream_id)
     schema = utils.load_json(get_abs_path(path))
-    dependencies = schema.pop("tap_xero_schema_dependencies", [])
+    dependencies = schema.pop("tap_schema_dependencies", [])
     refs = {}
     for sub_stream_id in dependencies:
         refs[sub_stream_id] = load_schema(sub_stream_id)

--- a/tap_xero/pull.py
+++ b/tap_xero/pull.py
@@ -91,6 +91,8 @@ class BankTransfersPull(IncrementingPull):
 
 
 class PaginatedPull(Puller):
+    FULL_PAGE_SIZE = 100
+
     def _paginate(self,
                   options={},
                   first_page_num=1,
@@ -109,6 +111,8 @@ class PaginatedPull(Puller):
             yield page, next_page_num
             curr_page_num = next_page_num
             num_pages_yielded += 1
+            if len(page) < self.FULL_PAGE_SIZE:
+                break
 
     def yield_pages(self):
         start = self._update_start_state()

--- a/tap_xero/schemas/bank_transactions.json
+++ b/tap_xero/schemas/bank_transactions.json
@@ -11,7 +11,7 @@
       ]
     },
     "Contact": {
-      "$ref": "#/definitions/contacts"
+      "$ref": "contacts"
     },
     "LineItems": {
       "type": [
@@ -19,11 +19,11 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/line_items"
+        "$ref": "line_items"
       }
     },
     "BankAccount": {
-      "$ref": "#/definitions/accounts"
+      "$ref": "accounts"
     },
     "IsReconciled": {
       "type": [
@@ -150,9 +150,9 @@
       ]
     }
   },
-  "definitions": {
-    "accounts": "FILLED IN BY tap-xero",
-    "contacts": "FILLED IN BY tap-xero",
-    "line_items": "FILLED IN BY tap-xero"
-  }
+  "tap_xero_schema_dependencies": [
+    "accounts",
+    "contacts",
+    "line_items"
+  ]
 }

--- a/tap_xero/schemas/bank_transactions.json
+++ b/tap_xero/schemas/bank_transactions.json
@@ -150,7 +150,7 @@
       ]
     }
   },
-  "tap_xero_schema_dependencies": [
+  "tap_schema_dependencies": [
     "accounts",
     "contacts",
     "line_items"

--- a/tap_xero/schemas/bank_transfers.json
+++ b/tap_xero/schemas/bank_transfers.json
@@ -5,10 +5,10 @@
   ],
   "properties": {
     "FromBankAccount": {
-      "$ref": "#/definitions/accounts"
+      "$ref": "accounts"
     },
     "ToBankAccount": {
-      "$ref": "#/definitions/accounts"
+      "$ref": "accounts"
     },
     "Amount": {
       "type": [
@@ -84,7 +84,7 @@
       "format": "date-time"
     }
   },
-  "definitions": {
-    "accounts": "FILLED IN BY tap-xero"
-  }
+  "tap_xero_schema_dependencies": [
+    "accounts"
+  ]
 }

--- a/tap_xero/schemas/bank_transfers.json
+++ b/tap_xero/schemas/bank_transfers.json
@@ -84,7 +84,7 @@
       "format": "date-time"
     }
   },
-  "tap_xero_schema_dependencies": [
+  "tap_schema_dependencies": [
     "accounts"
   ]
 }

--- a/tap_xero/schemas/contacts.json
+++ b/tap_xero/schemas/contacts.json
@@ -339,7 +339,7 @@
       ]
     }
   },
-  "tap_xero_schema_dependencies": [
+  "tap_schema_dependencies": [
     "addresses",
     "phones",
     "contact_groups",

--- a/tap_xero/schemas/contacts.json
+++ b/tap_xero/schemas/contacts.json
@@ -83,7 +83,7 @@
     },
     "Addresses": {
       "items": {
-        "$ref": "#/definitions/addresses"
+        "$ref": "addresses"
       },
       "type": [
         "null",
@@ -92,7 +92,7 @@
     },
     "Phones": {
       "items": {
-        "$ref": "#/definitions/phones"
+        "$ref": "phones"
       },
       "type": [
         "null",
@@ -186,7 +186,7 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/tracking_categories"
+        "$ref": "tracking_categories"
       }
     },
     "PurchasesTrackingCategories": {
@@ -195,7 +195,7 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/tracking_categories"
+        "$ref": "tracking_categories"
       }
     },
     "TrackingCategoryName": {
@@ -218,7 +218,7 @@
     },
     "ContactGroups": {
       "items": {
-        "$ref": "#/definitions/contact_groups"
+        "$ref": "contact_groups"
       },
       "type": [
         "null",
@@ -232,7 +232,7 @@
       ]
     },
     "BrandingTheme": {
-      "$ref": "#/definitions/branding_themes"
+      "$ref": "branding_themes"
     },
     "BatchPayments": {
       "type": [
@@ -339,11 +339,11 @@
       ]
     }
   },
-  "definitions": {
-    "addresses": "FILLED IN BY tap-xero",
-    "phones": "FILLED IN BY tap-xero",
-    "contact_groups": "FILLED IN BY tap-xero",
-    "branding_themes": "FILLED IN BY tap-xero",
-    "tracking_categories": "FILLED IN BY tap-xero"
-  }
+  "tap_xero_schema_dependencies": [
+    "addresses",
+    "phones",
+    "contact_groups",
+    "branding_themes",
+    "tracking_categories"
+  ]
 }

--- a/tap_xero/schemas/credit_notes.json
+++ b/tap_xero/schemas/credit_notes.json
@@ -11,7 +11,7 @@
       ]
     },
     "Contact": {
-      "$ref": "#/definitions/contacts"
+      "$ref": "contacts"
     },
     "Date": {
       "format": "date-time",
@@ -34,7 +34,7 @@
     },
     "LineItems": {
       "items": {
-        "$ref": "#/definitions/line_items"
+        "$ref": "line_items"
       },
       "type": [
         "null",
@@ -141,7 +141,7 @@
     },
     "Allocations": {
       "items": {
-        "$ref": "#/definitions/allocations"
+        "$ref": "allocations"
       },
       "type": [
         "null",
@@ -174,9 +174,9 @@
       ]
     }
   },
-  "definitions": {
-    "contacts": "FILLED IN BY tap-xero",
-    "line_items": "FILLED IN BY tap-xero",
-    "allocations": "FILLED IN BY tap-xero"
-  }
+  "tap_xero_schema_dependencies": [
+    "contacts",
+    "line_items",
+    "allocations"
+  ]
 }

--- a/tap_xero/schemas/credit_notes.json
+++ b/tap_xero/schemas/credit_notes.json
@@ -174,7 +174,7 @@
       ]
     }
   },
-  "tap_xero_schema_dependencies": [
+  "tap_schema_dependencies": [
     "contacts",
     "line_items",
     "allocations"

--- a/tap_xero/schemas/expense_claims.json
+++ b/tap_xero/schemas/expense_claims.json
@@ -91,7 +91,7 @@
       "format": "date-time"
     }
   },
-  "tap_xero_schema_dependencies": [
+  "tap_schema_dependencies": [
     "users",
     "receipts",
     "payments"

--- a/tap_xero/schemas/expense_claims.json
+++ b/tap_xero/schemas/expense_claims.json
@@ -5,7 +5,7 @@
   ],
   "properties": {
     "User": {
-      "$ref": "#/definitions/users"
+      "$ref": "users"
     },
     "Receipts": {
       "type": [
@@ -13,7 +13,7 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/receipts"
+        "$ref": "receipts"
       }
     },
     "ExpenseClaimID": {
@@ -27,7 +27,7 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/payments"
+        "$ref": "payments"
       }
     },
     "Status": {
@@ -91,9 +91,9 @@
       "format": "date-time"
     }
   },
-  "definitions": {
-    "users": "FILLED IN BY tap-xero",
-    "receipts": "FILLED IN BY tap-xero",
-    "payments": "FILLED IN BY tap-xero"
-  }
+  "tap_xero_schema_dependencies": [
+    "users",
+    "receipts",
+    "payments"
+  ]
 }

--- a/tap_xero/schemas/invoices.json
+++ b/tap_xero/schemas/invoices.json
@@ -274,7 +274,7 @@
       ]
     }
   },
-  "tap_xero_schema_dependencies": [
+  "tap_schema_dependencies": [
     "contacts",
     "payments",
     "prepayments",

--- a/tap_xero/schemas/invoices.json
+++ b/tap_xero/schemas/invoices.json
@@ -11,7 +11,7 @@
       ]
     },
     "Contact": {
-      "$ref": "#/definitions/contacts"
+      "$ref": "contacts"
     },
     "Date": {
       "format": "date-time",
@@ -45,7 +45,7 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/line_items"
+        "$ref": "line_items"
       }
     },
     "SubTotal": {
@@ -177,7 +177,7 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/payments"
+        "$ref": "payments"
       }
     },
     "CreditNotes": {
@@ -186,7 +186,7 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/credit_notes"
+        "$ref": "credit_notes"
       }
     },
     "Prepayments": {
@@ -195,7 +195,7 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/prepayments"
+        "$ref": "prepayments"
       }
     },
     "Overpayments": {
@@ -204,7 +204,7 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/overpayments"
+        "$ref": "overpayments"
       }
     },
     "AmountDue": {
@@ -274,12 +274,12 @@
       ]
     }
   },
-  "definitions": {
-    "contacts": "FILLED IN BY tap-xero",
-    "payments": "FILLED IN BY tap-xero",
-    "prepayments": "FILLED IN BY tap-xero",
-    "overpayments": "FILLED IN BY tap-xero",
-    "line_items": "FILLED IN BY tap-xero",
-    "credit_notes": "FILLED IN BY tap-xero"
-  }
+  "tap_xero_schema_dependencies": [
+    "contacts",
+    "payments",
+    "prepayments",
+    "overpayments",
+    "line_items",
+    "credit_notes"
+  ]
 }

--- a/tap_xero/schemas/journals.json
+++ b/tap_xero/schemas/journals.json
@@ -137,7 +137,7 @@
       ]
     }
   },
-  "tap_xero_schema_dependencies": [
+  "tap_schema_dependencies": [
     "tracking_categories"
   ]
 }

--- a/tap_xero/schemas/journals.json
+++ b/tap_xero/schemas/journals.json
@@ -118,7 +118,7 @@
           },
           "TrackingCategories": {
             "items": {
-              "$ref": "#/definitions/tracking_categories"
+              "$ref": "tracking_categories"
             },
             "type": [
               "null",
@@ -137,7 +137,7 @@
       ]
     }
   },
-  "definitions": {
-    "tracking_categories": "FILLED IN BY tap-xero"
-  }
+  "tap_xero_schema_dependencies": [
+    "tracking_categories"
+  ]
 }

--- a/tap_xero/schemas/line_items.json
+++ b/tap_xero/schemas/line_items.json
@@ -90,7 +90,7 @@
     },
     "Tracking": {
       "items": {
-        "$ref": "#/definitions/tracking_categories"
+        "$ref": "tracking_categories"
       },
       "type": [
         "null",
@@ -98,7 +98,7 @@
       ]
     }
   },
-  "definitions": {
-    "tracking_categories": "FILLED IN BY tap-xero"
-  }
+  "tap_xero_schema_dependencies": [
+    "tracking_categories"
+  ]
 }

--- a/tap_xero/schemas/line_items.json
+++ b/tap_xero/schemas/line_items.json
@@ -98,7 +98,7 @@
       ]
     }
   },
-  "tap_xero_schema_dependencies": [
+  "tap_schema_dependencies": [
     "tracking_categories"
   ]
 }

--- a/tap_xero/schemas/manual_journals.json
+++ b/tap_xero/schemas/manual_journals.json
@@ -88,7 +88,7 @@
           },
           "Tracking": {
             "items": {
-              "$ref": "#/definitions/tracking_categories"
+              "$ref": "tracking_categories"
             },
             "type": [
               "null",
@@ -129,7 +129,7 @@
       ]
     }
   },
-  "definitions": {
-    "tracking_categories": "FILLED IN BY tap-xero"
-  }
+  "tap_xero_schema_dependencies": [
+    "tracking_categories"
+  ]
 }

--- a/tap_xero/schemas/manual_journals.json
+++ b/tap_xero/schemas/manual_journals.json
@@ -129,7 +129,7 @@
       ]
     }
   },
-  "tap_xero_schema_dependencies": [
+  "tap_schema_dependencies": [
     "tracking_categories"
   ]
 }

--- a/tap_xero/schemas/organisations.json
+++ b/tap_xero/schemas/organisations.json
@@ -168,7 +168,7 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/addresses"
+        "$ref": "addresses"
       }
     },
     "Phones": {
@@ -177,7 +177,7 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/phones"
+        "$ref": "phones"
       }
     },
     "ExternalLinks": {
@@ -255,8 +255,8 @@
       }
     }
   },
-  "definitions": {
-    "addresses": "FILLED IN BY tap-xero",
-    "phones": "FILLED IN BY tap-xero"
-  }
+  "tap_xero_schema_dependencies": [
+    "addresses",
+    "phones"
+  ]
 }

--- a/tap_xero/schemas/organisations.json
+++ b/tap_xero/schemas/organisations.json
@@ -255,7 +255,7 @@
       }
     }
   },
-  "tap_xero_schema_dependencies": [
+  "tap_schema_dependencies": [
     "addresses",
     "phones"
   ]

--- a/tap_xero/schemas/overpayments.json
+++ b/tap_xero/schemas/overpayments.json
@@ -152,7 +152,7 @@
       "format": "date-time"
     }
   },
-  "tap_xero_schema_dependencies": [
+  "tap_schema_dependencies": [
     "contacts",
     "line_items",
     "payments",

--- a/tap_xero/schemas/overpayments.json
+++ b/tap_xero/schemas/overpayments.json
@@ -11,7 +11,7 @@
       ]
     },
     "Contact": {
-      "$ref": "#/definitions/contacts"
+      "$ref": "contacts"
     },
     "Date": {
       "type": [
@@ -34,7 +34,7 @@
     },
     "LineItems": {
       "items": {
-        "$ref": "#/definitions/line_items"
+        "$ref": "line_items"
       },
       "type": [
         "null",
@@ -120,7 +120,7 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/allocations"
+        "$ref": "allocations"
       }
     },
     "Payments": {
@@ -129,7 +129,7 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/payments"
+        "$ref": "payments"
       }
     },
     "HasAttachments": {
@@ -152,10 +152,10 @@
       "format": "date-time"
     }
   },
-  "definitions": {
-    "contacts": "FILLED IN BY tap-xero",
-    "line_items": "FILLED IN BY tap-xero",
-    "payments": "FILLED IN BY tap-xero",
-    "allocations": "FILLED IN BY tap-xero"
-  }
+  "tap_xero_schema_dependencies": [
+    "contacts",
+    "line_items",
+    "payments",
+    "allocations"
+  ]
 }

--- a/tap_xero/schemas/payments.json
+++ b/tap_xero/schemas/payments.json
@@ -65,7 +65,7 @@
       "format": "date-time"
     },
     "Account": {
-      "$ref": "#/definitions/accounts"
+      "$ref": "accounts"
     },
     "Invoice": {
       "type": [
@@ -161,7 +161,7 @@
       ]
     }
   },
-  "definitions": {
-    "accounts": "FILLED IN BY tap-xero"
-  }
+  "tap_xero_schema_dependencies": [
+    "accounts"
+  ]
 }

--- a/tap_xero/schemas/payments.json
+++ b/tap_xero/schemas/payments.json
@@ -161,7 +161,7 @@
       ]
     }
   },
-  "tap_xero_schema_dependencies": [
+  "tap_schema_dependencies": [
     "accounts"
   ]
 }

--- a/tap_xero/schemas/prepayments.json
+++ b/tap_xero/schemas/prepayments.json
@@ -143,7 +143,7 @@
       ]
     }
   },
-  "tap_xero_schema_dependencies": [
+  "tap_schema_dependencies": [
     "allocations",
     "contacts",
     "line_items"

--- a/tap_xero/schemas/prepayments.json
+++ b/tap_xero/schemas/prepayments.json
@@ -11,7 +11,7 @@
       ]
     },
     "Contact": {
-      "$ref": "#/definitions/contacts"
+      "$ref": "contacts"
     },
     "Date": {
       "format": "date-time",
@@ -34,7 +34,7 @@
     },
     "LineItems": {
       "items": {
-        "$ref": "#/definitions/line_items"
+        "$ref": "line_items"
       },
       "type": [
         "null",
@@ -115,7 +115,7 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/allocations"
+        "$ref": "allocations"
       }
     },
     "HasAttachments": {
@@ -143,9 +143,9 @@
       ]
     }
   },
-  "definitions": {
-    "allocations": "FILLED IN BY tap-xero",
-    "contacts": "FILLED IN BY tap-xero",
-    "line_items": "FILLED IN BY tap-xero"
-  }
+  "tap_xero_schema_dependencies": [
+    "allocations",
+    "contacts",
+    "line_items"
+  ]
 }

--- a/tap_xero/schemas/purchase_orders.json
+++ b/tap_xero/schemas/purchase_orders.json
@@ -216,7 +216,7 @@
       ]
     }
   },
-  "tap_xero_schema_dependencies": [
+  "tap_schema_dependencies": [
     "contacts",
     "line_items"
   ]

--- a/tap_xero/schemas/purchase_orders.json
+++ b/tap_xero/schemas/purchase_orders.json
@@ -5,7 +5,7 @@
   ],
   "properties": {
     "Contact": {
-      "$ref": "#/definitions/contacts"
+      "$ref": "contacts"
     },
     "Date": {
       "format": "date-time",
@@ -45,7 +45,7 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/line_items"
+        "$ref": "line_items"
       }
     },
     "BrandingThemeID": {
@@ -216,8 +216,8 @@
       ]
     }
   },
-  "definitions": {
-    "contacts": "FILLED IN BY tap-xero",
-    "line_items": "FILLED IN BY tap-xero"
-  }
+  "tap_xero_schema_dependencies": [
+    "contacts",
+    "line_items"
+  ]
 }

--- a/tap_xero/schemas/receipts.json
+++ b/tap_xero/schemas/receipts.json
@@ -12,7 +12,7 @@
       "format": "date-time"
     },
     "Contact": {
-      "$ref": "#/definitions/contacts"
+      "$ref": "contacts"
     },
     "Lineitems": {
       "type": [
@@ -20,11 +20,11 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/line_items"
+        "$ref": "line_items"
       }
     },
     "User": {
-      "$ref": "#/definitions/users"
+      "$ref": "users"
     },
     "Reference": {
       "type": [
@@ -114,9 +114,9 @@
       ]
     }
   },
-  "definitions": {
-    "contacts": "FILLED IN BY tap-xero",
-    "line_items": "FILLED IN BY tap-xero",
-    "users": "FILLED IN BY tap-xero"
-  }
+  "tap_xero_schema_dependencies": [
+    "contacts",
+    "line_items",
+    "users"
+  ]
 }

--- a/tap_xero/schemas/receipts.json
+++ b/tap_xero/schemas/receipts.json
@@ -114,7 +114,7 @@
       ]
     }
   },
-  "tap_xero_schema_dependencies": [
+  "tap_schema_dependencies": [
     "contacts",
     "line_items",
     "users"

--- a/tap_xero/schemas/repeating_invoices.json
+++ b/tap_xero/schemas/repeating_invoices.json
@@ -155,7 +155,7 @@
       ]
     }
   },
-  "tap_xero_schema_dependencies": [
+  "tap_schema_dependencies": [
     "contacts",
     "line_items"
   ]

--- a/tap_xero/schemas/repeating_invoices.json
+++ b/tap_xero/schemas/repeating_invoices.json
@@ -11,7 +11,7 @@
       ]
     },
     "Contact": {
-      "$ref": "#/definitions/contacts"
+      "$ref": "contacts"
     },
     "Schedule": {
       "type": [
@@ -67,7 +67,7 @@
     },
     "LineItems": {
       "items": {
-        "$ref": "#/definitions/line_items"
+        "$ref": "line_items"
       },
       "type": [
         "null",
@@ -155,8 +155,8 @@
       ]
     }
   },
-  "definitions": {
-    "contacts": "FILLED IN BY tap-xero",
-    "line_items": "FILLED IN BY tap-xero"
-  }
+  "tap_xero_schema_dependencies": [
+    "contacts",
+    "line_items"
+  ]
 }

--- a/tap_xero/xero.py
+++ b/tap_xero/xero.py
@@ -1,13 +1,14 @@
 import requests
 from os.path import join
 import re
-from datetime import datetime
+from datetime import datetime, date, time
 import xero.utils
 from singer.utils import strftime
 import json
 import six
 from .credentials import build_oauth
 import decimal
+import pytz
 
 BASE_URL = "https://api.xero.com/api.xro/2.0"
 
@@ -20,6 +21,9 @@ def _json_load_object_hook(_dict):
         if isinstance(value, six.string_types):
             value = xero.utils.parse_date(value)
             if value:
+                if type(value) == date:
+                    value = datetime.combine(value, time.min)
+                value = value.replace(tzinfo=pytz.UTC)
                 _dict[key] = strftime(value)
     return _dict
 


### PR DESCRIPTION
This is the last thing necessary for the Xero tap. It upgrades to the latest singer-python so that the `$ref` feature of JSON schema can be used in conjunction with the changes in `target-stitch` to properly get decimal types in Redshift.

After making these changes I did a full sync of data into Redshift. 637 records were sent to Stitch. Confirmed the data type of the expected columns were now `numeric(38,6)`.