### PR TITLE
do not select catalogs by default

### DIFF
--- a/tap_xero/__init__.py
+++ b/tap_xero/__init__.py
@@ -96,7 +96,7 @@ def discover():
     result = {"streams": []}
     for stream in STREAMS:
         schema = load_schema(stream.tap_stream_id)
-        schema["selected"] = True
+        schema["selected"] = False
         result["streams"].append(
             dict(stream=stream.tap_stream_id,
                  tap_stream_id=stream.tap_stream_id,


### PR DESCRIPTION
Based on other taps I have looked at, it seems like the standard behavior is to not select streams by default. If that is the case, this change makes it happen.