### PR TITLE
Schemas additional properties

### DIFF
--- a/tap_xero/schemas/accounts.json
+++ b/tap_xero/schemas/accounts.json
@@ -112,5 +112,6 @@
         "boolean"
       ]
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/addresses.json
+++ b/tap_xero/schemas/addresses.json
@@ -64,5 +64,6 @@
         "string"
       ]
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/allocations.json
+++ b/tap_xero/schemas/allocations.json
@@ -16,9 +16,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -51,7 +51,9 @@
             "string"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/allocations.json
+++ b/tap_xero/schemas/allocations.json
@@ -23,37 +23,11 @@
       "exclusiveMaximum": true
     },
     "Invoice": {
-      "type": [
-        "null",
-        "object"
-      ],
-      "properties": {
-        "IsDiscounted": {
-          "type": [
-            "null",
-            "boolean"
-          ]
-        },
-        "HasErrors": {
-          "type": [
-            "null",
-            "boolean"
-          ]
-        },
-        "InvoiceID": {
-          "type": [
-            "string"
-          ]
-        },
-        "InvoiceNumber": {
-          "type": [
-            "null",
-            "string"
-          ]
-        }
-      },
-      "additionalProperties": false
+      "$ref": "nested_invoice"
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "tap_schema_dependencies": [
+    "nested_invoice"
+  ]
 }

--- a/tap_xero/schemas/attachments.json
+++ b/tap_xero/schemas/attachments.json
@@ -1,0 +1,15 @@
+{
+  "type": [
+    "null",
+    "array"
+  ],
+  "items": {
+    "type": [
+      "null",
+      "object"
+    ],
+    "properties": {
+    },
+    "additionalProperties": false
+  }
+}

--- a/tap_xero/schemas/bank_transactions.json
+++ b/tap_xero/schemas/bank_transactions.json
@@ -62,9 +62,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -91,9 +91,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -102,9 +102,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -113,9 +113,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -154,5 +154,6 @@
     "accounts",
     "contacts",
     "line_items"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/bank_transfers.json
+++ b/tap_xero/schemas/bank_transfers.json
@@ -15,9 +15,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -45,9 +45,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -86,5 +86,6 @@
   },
   "tap_schema_dependencies": [
     "accounts"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/branding_themes.json
+++ b/tap_xero/schemas/branding_themes.json
@@ -28,5 +28,6 @@
         "string"
       ]
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/contact_groups.json
+++ b/tap_xero/schemas/contact_groups.json
@@ -27,5 +27,6 @@
         "boolean"
       ]
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/contacts.json
+++ b/tap_xero/schemas/contacts.json
@@ -337,11 +337,17 @@
         "boolean"
       ]
     },
+    "Attachments": {
+      "$ref": "attachments"
+    },
     "HasValidationErrors": {
       "type": [
         "null",
         "boolean"
       ]
+    },
+    "ValidationErrors": {
+      "$ref": "validation_errors"
     }
   },
   "tap_schema_dependencies": [
@@ -349,7 +355,9 @@
     "phones",
     "contact_groups",
     "branding_themes",
-    "tracking_categories"
+    "tracking_categories",
+    "validation_errors",
+    "attachments"
   ],
   "additionalProperties": false
 }

--- a/tap_xero/schemas/contacts.json
+++ b/tap_xero/schemas/contacts.json
@@ -159,7 +159,8 @@
               "boolean"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "XeroNetworkKey": {
@@ -270,7 +271,8 @@
             "string"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Discount": {
       "type": [
@@ -302,7 +304,8 @@
                 "number"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         },
         "AccountsPayable": {
           "type": [
@@ -322,9 +325,11 @@
                 "number"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "HasAttachments": {
       "type": [
@@ -345,5 +350,6 @@
     "contact_groups",
     "branding_themes",
     "tracking_categories"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/credit_notes.json
+++ b/tap_xero/schemas/credit_notes.json
@@ -46,9 +46,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -57,9 +57,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -68,9 +68,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -122,9 +122,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -133,9 +133,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -178,5 +178,6 @@
     "contacts",
     "line_items",
     "allocations"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/currencies.json
+++ b/tap_xero/schemas/currencies.json
@@ -15,5 +15,6 @@
         "string"
       ]
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/employees.json
+++ b/tap_xero/schemas/employees.json
@@ -40,5 +40,6 @@
         "string"
       ]
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/expense_claims.json
+++ b/tap_xero/schemas/expense_claims.json
@@ -48,9 +48,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -59,9 +59,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -70,9 +70,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -95,5 +95,6 @@
     "users",
     "receipts",
     "payments"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/invoices.json
+++ b/tap_xero/schemas/invoices.json
@@ -53,9 +53,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -64,9 +64,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -75,9 +75,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -86,9 +86,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -110,9 +110,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -212,9 +212,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -223,9 +223,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -241,9 +241,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -281,5 +281,6 @@
     "overpayments",
     "line_items",
     "credit_notes"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/items.json
+++ b/tap_xero/schemas/items.json
@@ -64,9 +64,9 @@
             "null",
             "number"
           ],
-          "minimum": -10e32,
-          "maximum": 10e32,
-          "multipleOf": 10e-6,
+          "minimum": -1e+33,
+          "maximum": 1e+33,
+          "multipleOf": 1e-05,
           "exclusiveMinimum": true,
           "exclusiveMaximum": true
         },
@@ -80,7 +80,8 @@
       "type": [
         "null",
         "object"
-      ]
+      ],
+      "additionalProperties": false
     },
     "SalesDetails": {
       "properties": {
@@ -95,9 +96,9 @@
             "null",
             "number"
           ],
-          "minimum": -10e32,
-          "maximum": 10e32,
-          "multipleOf": 10e-6,
+          "minimum": -1e+33,
+          "maximum": 1e+33,
+          "multipleOf": 1e-05,
           "exclusiveMinimum": true,
           "exclusiveMaximum": true
         },
@@ -111,7 +112,8 @@
       "type": [
         "null",
         "object"
-      ]
+      ],
+      "additionalProperties": false
     },
     "IsTrackedAsInventory": {
       "type": [
@@ -144,5 +146,6 @@
       ],
       "format": "date-time"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/journals.json
+++ b/tap_xero/schemas/journals.json
@@ -129,7 +129,8 @@
         "type": [
           "null",
           "object"
-        ]
+        ],
+        "additionalProperties": false
       },
       "type": [
         "null",
@@ -139,5 +140,6 @@
   },
   "tap_schema_dependencies": [
     "tracking_categories"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/line_items.json
+++ b/tap_xero/schemas/line_items.json
@@ -15,9 +15,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -26,9 +26,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -60,9 +60,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -71,9 +71,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -82,9 +82,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -100,5 +100,6 @@
   },
   "tap_schema_dependencies": [
     "tracking_categories"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/linked_transactions.json
+++ b/tap_xero/schemas/linked_transactions.json
@@ -64,5 +64,6 @@
       ],
       "format": "date-time"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/manual_journals.json
+++ b/tap_xero/schemas/manual_journals.json
@@ -45,9 +45,9 @@
               "null",
               "number"
             ],
-            "minimum": -10e32,
-            "maximum": 10e32,
-            "multipleOf": 10e-6,
+            "minimum": -1e+33,
+            "maximum": 1e+33,
+            "multipleOf": 1e-05,
             "exclusiveMinimum": true,
             "exclusiveMaximum": true
           },
@@ -62,9 +62,9 @@
               "null",
               "number"
             ],
-            "minimum": -10e32,
-            "maximum": 10e32,
-            "multipleOf": 10e-6,
+            "minimum": -1e+33,
+            "maximum": 1e+33,
+            "multipleOf": 1e-05,
             "exclusiveMinimum": true,
             "exclusiveMaximum": true
           },
@@ -95,7 +95,8 @@
               "array"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "Url": {
@@ -131,5 +132,6 @@
   },
   "tap_schema_dependencies": [
     "tracking_categories"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/nested_invoice.json
+++ b/tap_xero/schemas/nested_invoice.json
@@ -20,6 +20,13 @@
         "string"
       ]
     },
+    "DueDate": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "Status": {
       "type": [
         "null",
@@ -33,26 +40,15 @@
       ]
     },
     "LineItems": {
-      "items": {
-        "$ref": "line_items"
-      },
       "type": [
         "null",
         "array"
-      ]
+      ],
+      "items": {
+        "$ref": "line_items"
+      }
     },
     "SubTotal": {
-      "type": [
-        "null",
-        "number"
-      ],
-      "minimum": -1e+33,
-      "maximum": 1e+33,
-      "multipleOf": 1e-05,
-      "exclusiveMinimum": true,
-      "exclusiveMaximum": true
-    },
-    "AppliedAmount": {
       "type": [
         "null",
         "number"
@@ -85,6 +81,17 @@
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
+    "TotalDiscount": {
+      "type": [
+        "null",
+        "number"
+      ],
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
+      "exclusiveMinimum": true,
+      "exclusiveMaximum": true
+    },
     "UpdatedDateUTC": {
       "format": "date-time",
       "type": [
@@ -98,36 +105,6 @@
         "string"
       ]
     },
-    "FullyPaidOnDate": {
-      "format": "date-time",
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "CreditNoteID": {
-      "type": [
-        "string"
-      ]
-    },
-    "CreditNoteNumber": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "Reference": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "SentToContact": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "CurrencyRate": {
       "type": [
         "null",
@@ -139,7 +116,62 @@
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
-    "RemainingCredit": {
+    "InvoiceID": {
+      "type": [
+        "string"
+      ]
+    },
+    "InvoiceNumber": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "Reference": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "BrandingThemeID": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "Url": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "SentToContact": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "ExpectedPaymentDate": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "PlannedPaymentDate": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "HasAttachments": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "AmountDue": {
       "type": [
         "null",
         "number"
@@ -150,22 +182,49 @@
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
-    "Allocations": {
-      "items": {
-        "$ref": "allocations"
-      },
+    "AmountPaid": {
       "type": [
         "null",
-        "array"
-      ]
+        "number"
+      ],
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
+      "exclusiveMinimum": true,
+      "exclusiveMaximum": true
     },
-    "BrandingThemeID": {
+    "FullyPaidOnDate": {
+      "format": "date-time",
       "type": [
         "null",
         "string"
       ]
     },
-    "HasAttachments": {
+    "AmountCredited": {
+      "type": [
+        "null",
+        "number"
+      ],
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
+      "exclusiveMinimum": true,
+      "exclusiveMaximum": true
+    },
+    "DueDateString": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "IsDiscounted": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "HasErrors": {
       "type": [
         "null",
         "boolean"
@@ -177,18 +236,11 @@
         "null",
         "string"
       ]
-    },
-    "ID": {
-      "type": [
-        "null",
-        "string"
-      ]
     }
   },
   "tap_schema_dependencies": [
     "contacts",
-    "line_items",
-    "allocations"
+    "line_items"
   ],
   "additionalProperties": false
 }

--- a/tap_xero/schemas/organisations.json
+++ b/tap_xero/schemas/organisations.json
@@ -203,7 +203,8 @@
               "string"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "PaymentTerms": {
@@ -230,7 +231,8 @@
                 "string"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         },
         "Bills": {
           "type": [
@@ -250,13 +252,16 @@
                 "string"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     }
   },
   "tap_schema_dependencies": [
     "addresses",
     "phones"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/overpayments.json
+++ b/tap_xero/schemas/overpayments.json
@@ -46,9 +46,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -57,9 +57,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -68,9 +68,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -97,9 +97,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -108,9 +108,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -157,5 +157,6 @@
     "line_items",
     "payments",
     "allocations"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/payments.json
+++ b/tap_xero/schemas/payments.json
@@ -68,18 +68,7 @@
       "$ref": "accounts"
     },
     "Invoice": {
-      "type": [
-        "null",
-        "object"
-      ],
-      "properties": {
-        "InvoiceID": {
-          "type": [
-            "string"
-          ]
-        }
-      },
-      "additionalProperties": false
+      "$ref": "nested_invoice"
     },
     "CreditNote": {
       "type": [
@@ -162,10 +151,17 @@
         "null",
         "boolean"
       ]
+    },
+    "BatchPaymentID": {
+      "type": [
+        "null",
+        "string"
+      ]
     }
   },
   "tap_schema_dependencies": [
-    "accounts"
+    "accounts",
+    "nested_invoice"
   ],
   "additionalProperties": false
 }

--- a/tap_xero/schemas/payments.json
+++ b/tap_xero/schemas/payments.json
@@ -16,9 +16,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -27,9 +27,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -78,7 +78,8 @@
             "string"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "CreditNote": {
       "type": [
@@ -91,7 +92,8 @@
             "string"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Prepayments": {
       "type": [
@@ -109,7 +111,8 @@
               "string"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "Overpayment": {
@@ -128,8 +131,8 @@
               "string"
             ]
           }
-        }
-
+        },
+        "additionalProperties": false
       }
     },
     "BankAmount": {
@@ -137,9 +140,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -163,5 +166,6 @@
   },
   "tap_schema_dependencies": [
     "accounts"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/phones.json
+++ b/tap_xero/schemas/phones.json
@@ -28,5 +28,6 @@
         "string"
       ]
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/prepayments.json
+++ b/tap_xero/schemas/prepayments.json
@@ -46,9 +46,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -57,9 +57,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -86,9 +86,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -103,9 +103,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -129,9 +129,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -147,5 +147,6 @@
     "allocations",
     "contacts",
     "line_items"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/purchase_orders.json
+++ b/tap_xero/schemas/purchase_orders.json
@@ -113,9 +113,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -124,9 +124,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -135,9 +135,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -146,9 +146,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -157,9 +157,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -219,5 +219,6 @@
   "tap_schema_dependencies": [
     "contacts",
     "line_items"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/receipts.json
+++ b/tap_xero/schemas/receipts.json
@@ -43,9 +43,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -54,9 +54,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -65,9 +65,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -118,5 +118,6 @@
     "contacts",
     "line_items",
     "users"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/receipts.json
+++ b/tap_xero/schemas/receipts.json
@@ -14,7 +14,7 @@
     "Contact": {
       "$ref": "contacts"
     },
-    "Lineitems": {
+    "LineItems": {
       "type": [
         "null",
         "array"
@@ -112,12 +112,20 @@
         "null",
         "string"
       ]
+    },
+    "ValidationErrors": {
+      "$ref": "validation_errors"
+    },
+    "Attachments": {
+      "$ref": "attachments"
     }
   },
   "tap_schema_dependencies": [
     "contacts",
     "line_items",
-    "users"
+    "users",
+    "validation_errors",
+    "attachments"
   ],
   "additionalProperties": false
 }

--- a/tap_xero/schemas/repeating_invoices.json
+++ b/tap_xero/schemas/repeating_invoices.json
@@ -63,7 +63,8 @@
             "integer"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "LineItems": {
       "items": {
@@ -109,9 +110,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -120,9 +121,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -131,9 +132,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -158,5 +159,6 @@
   "tap_schema_dependencies": [
     "contacts",
     "line_items"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/tax_rates.json
+++ b/tap_xero/schemas/tax_rates.json
@@ -43,13 +43,14 @@
               "null",
               "number"
             ],
-            "minimum": -10e32,
-            "maximum": 10e32,
-            "multipleOf": 10e-6,
+            "minimum": -1e+33,
+            "maximum": 1e+33,
+            "multipleOf": 1e-05,
             "exclusiveMinimum": true,
             "exclusiveMaximum": true
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "Status": {
@@ -99,9 +100,9 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },
@@ -110,11 +111,12 @@
         "null",
         "number"
       ],
-      "minimum": -10e32,
-      "maximum": 10e32,
-      "multipleOf": 10e-6,
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/tracking_categories.json
+++ b/tap_xero/schemas/tracking_categories.json
@@ -21,6 +21,12 @@
         "string"
       ]
     },
+    "TrackingOptionID": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "Options": {
       "items": {
         "type": [

--- a/tap_xero/schemas/tracking_categories.json
+++ b/tap_xero/schemas/tracking_categories.json
@@ -15,6 +15,12 @@
         "string"
       ]
     },
+    "Option": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "Options": {
       "items": {
         "type": [

--- a/tap_xero/schemas/tracking_categories.json
+++ b/tap_xero/schemas/tracking_categories.json
@@ -64,7 +64,8 @@
               "boolean"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       },
       "type": [
         "null",
@@ -77,5 +78,6 @@
         "string"
       ]
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/users.json
+++ b/tap_xero/schemas/users.json
@@ -46,5 +46,6 @@
         "string"
       ]
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/tap_xero/schemas/users.json
+++ b/tap_xero/schemas/users.json
@@ -45,7 +45,13 @@
         "null",
         "string"
       ]
+    },
+    "ValidationErrors": {
+      "$ref": "validation_errors"
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "tap_schema_dependencies": [
+    "validation_errors"
+  ]
 }

--- a/tap_xero/schemas/validation_errors.json
+++ b/tap_xero/schemas/validation_errors.json
@@ -1,0 +1,21 @@
+{
+  "type": [
+    "null",
+    "array"
+  ],
+  "items": {
+    "type": [
+      "null",
+      "object"
+    ],
+    "properties": {
+      "Message": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/tap_xero/streams.py
+++ b/tap_xero/streams.py
@@ -9,6 +9,7 @@ from singer import metrics
 import backoff
 from .xero import XeroClient
 from . import credentials
+from . import transform
 
 LOGGER = singer.get_logger()
 
@@ -163,6 +164,28 @@ class LinkedTransactionsPull(Puller):
         self._offset.pop("page", None)
 
 
+class CreditNotes(PaginatedPull):
+    def yield_pages(self):
+        for credit_notes in super().yield_pages():
+            transform.format_credit_notes(credit_notes)
+            yield credit_notes
+
+
+class ContactGroups(Puller):
+    def yield_pages(self):
+        contact_groups = self._make_request()
+        transform.format_contact_groups(contact_groups)
+        yield contact_groups
+
+
+class Contacts(PaginatedPull):
+    def yield_pages(self):
+        for contacts in super().yield_pages():
+            for contact in contacts:
+                transform.format_contact_groups(contact["ContactGroups"])
+            yield contacts
+
+
 class EverythingPull(Puller):
     def yield_pages(self):
         yield self._make_request()
@@ -180,8 +203,8 @@ all_streams = [
     # UpdatedDateUTC property and support the Modified After, order, and page
     # parameters
     Stream("bank_transactions", ["BankTransactionID"], PaginatedPull),
-    Stream("contacts", ["ContactID"], PaginatedPull),
-    Stream("credit_notes", ["CreditNoteID"], PaginatedPull),
+    Stream("contacts", ["ContactID"], Contacts),
+    Stream("credit_notes", ["CreditNoteID"], CreditNotes),
     Stream("invoices", ["InvoiceID"], PaginatedPull),
     Stream("manual_journals", ["ManualJournalID"], PaginatedPull),
     Stream("overpayments", ["OverpaymentID"], PaginatedPull),
@@ -208,7 +231,7 @@ all_streams = [
     # These endpoints do not support the Modified After header (or paging), so
     # we must pull all the data each time.
     Stream("branding_themes", ["BrandingThemeID"], EverythingPull),
-    Stream("contact_groups", ["ContactGroupID"], EverythingPull),
+    Stream("contact_groups", ["ContactGroupID"], ContactGroups),
     Stream("currencies", ["Code"], EverythingPull),
     Stream("organisations", ["OrganisationID"], EverythingPull),
     Stream("repeating_invoices", ["RepeatingInvoiceID"], EverythingPull),

--- a/tap_xero/streams.py
+++ b/tap_xero/streams.py
@@ -181,9 +181,29 @@ class ContactGroups(Puller):
 class Contacts(PaginatedPull):
     def yield_pages(self):
         for contacts in super().yield_pages():
-            for contact in contacts:
-                transform.format_contact_groups(contact["ContactGroups"])
+            transform.format_contacts(contacts)
             yield contacts
+
+
+class Payments(IncrementingPull):
+    def yield_pages(self):
+        for payments in super().yield_pages():
+            transform.format_payments(payments)
+            yield payments
+
+
+class Receipts(IncrementingPull):
+    def yield_pages(self):
+        for receipts in super().yield_pages():
+            transform.format_receipts(receipts)
+            yield receipts
+
+
+class Users(IncrementingPull):
+    def yield_pages(self):
+        for users in super().yield_pages():
+            transform.format_users(users)
+            yield users
 
 
 class EverythingPull(Puller):
@@ -223,9 +243,9 @@ all_streams = [
     Stream("employees", ["EmployeeID"], IncrementingPull),
     Stream("expense_claims", ["ExpenseClaimID"], IncrementingPull),
     Stream("items", ["ItemID"], IncrementingPull),
-    Stream("payments", ["PaymentID"], IncrementingPull),
-    Stream("receipts", ["ReceiptID"], IncrementingPull),
-    Stream("users", ["UserID"], IncrementingPull),
+    Stream("payments", ["PaymentID"], Payments),
+    Stream("receipts", ["ReceiptID"], Receipts),
+    Stream("users", ["UserID"], Users),
 
     # PULL EVERYTHING STREAMS
     # These endpoints do not support the Modified After header (or paging), so

--- a/tap_xero/transform.py
+++ b/tap_xero/transform.py
@@ -1,11 +1,14 @@
+def format_nested_invoice(invoice):
+    invoice.pop("Prepayments", None)
+    invoice.pop("Payments", None)
+    invoice.pop("CreditNotes", None)
+    invoice.pop("Overpayments", None)
+
+
 def format_allocations(allocations):
     for allocation in allocations:
         invoice = allocation.get("Invoice", {})
-        invoice.pop("Prepayments", None)
-        invoice.pop("Payments", None)
-        invoice.pop("CreditNotes", None)
-        invoice.pop("LineItems", None)
-        invoice.pop("Overpayments", None)
+        format_nested_invoice(invoice)
 
 
 def format_credit_notes(credit_notes):
@@ -17,3 +20,30 @@ def format_credit_notes(credit_notes):
 def format_contact_groups(contact_groups):
     for contact_group in contact_groups:
         contact_group.pop("Contacts", None)
+
+
+def format_payments(payments):
+    for payment in payments:
+        invoice = payment.get("Invoice", {})
+        format_nested_invoice(invoice)
+
+
+def strip_warnings(records):
+    for record in records:
+        record.pop("Warnings", None)
+
+
+format_users = strip_warnings
+
+
+def format_receipts(receipts):
+    strip_warnings(receipts)
+    for receipt in receipts:
+        receipt.get("User", {}).pop("Warnings", None)
+        receipt.get("Contact", {}).pop("Warnings", None)
+
+
+def format_contacts(contacts):
+    strip_warnings(contacts)
+    for contact in contacts:
+        format_contact_groups(contact["ContactGroups"])

--- a/tap_xero/transform.py
+++ b/tap_xero/transform.py
@@ -1,0 +1,19 @@
+def format_allocations(allocations):
+    for allocation in allocations:
+        invoice = allocation.get("Invoice", {})
+        invoice.pop("Prepayments", None)
+        invoice.pop("Payments", None)
+        invoice.pop("CreditNotes", None)
+        invoice.pop("LineItems", None)
+        invoice.pop("Overpayments", None)
+
+
+def format_credit_notes(credit_notes):
+    for credit_note in credit_notes:
+        credit_note.pop("Payments", None)
+        format_allocations(credit_note.get("Allocations", []))
+
+
+def format_contact_groups(contact_groups):
+    for contact_group in contact_groups:
+        contact_group.pop("Contacts", None)


### PR DESCRIPTION
This branch adds `"additionalProperties": false` to all objects in the Xero schemas.

Unfortunately, when I originally wrote the Xero tap, I thought `"additionalProperties": false` was the default. As a result there were quite a few properties being thrown onto the schemas I was unaware of. This branch implements fixes for all those that arose during testing against my development account.

A difficulty I had here was that the Xero resources all reference each other, making the schemas complex and difficult to write without hitting circular dependencies. As a result, my first take at fixing issues in this branch was to remove nested objects where I thought it made sense.

For example, wherever I encountered an "Invoice" object nested inside some other object, I stripped out the payments, overpayments, etc. These objects (payments, overpayments, etc) already have a reference to the child invoice.

Another issue I encountered in this branch was that several objects have a "Warnings" array inside them. "Warnings" is not documented anywhere in the Xero docs that I could find and I could not figure out how to get the sample data to return any warnings. As a result I don't know what structure "Warnings" take. My solution for now was to just remove this wherever it is seen.

## Testing

- I did a full sync from my own test account, which has a fair amount of data, and synced it through target-stitch.