### PR TITLE
Adding ExpectedPaymentDateString to invoice schema

### DIFF
--- a/tap_xero/schemas/invoices.json
+++ b/tap_xero/schemas/invoices.json
@@ -158,6 +158,13 @@
       ],
       "format": "date-time"
     },
+    "ExpectedPaymentDateString": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "PlannedPaymentDate": {
       "type": [
         "null",


### PR DESCRIPTION
There was one more missing schema element (hopefully this is the last)... related to #17 and #18 