### PR TITLE
Fix usage of the `since` parameter

### DIFF
--- a/tap_xero/__init__.py
+++ b/tap_xero/__init__.py
@@ -141,6 +141,6 @@ def main():
         LOGGER.critical(exc)
         raise exc
 
-        
+
 if __name__ == "__main__":
     main()

--- a/tap_xero/http.py
+++ b/tap_xero/http.py
@@ -33,12 +33,6 @@ class XeroClient(object):
         self.session = requests.Session()
         self.oauth = build_oauth(config)
         self.user_agent = config.get("user_agent")
-        self._datetime_pattern = re.compile(r"\/Date\((\d+)\)\/")
-
-    def _format_since(self, since):
-        if isinstance(since, datetime):
-            return since.strftime('%a, %d %b %Y %H:%M:%S GMT')
-        return '"{}"'.format(since)
 
     def update_credentials(self, new_config):
         self.oauth = build_oauth(new_config)
@@ -50,7 +44,7 @@ class XeroClient(object):
         if self.user_agent:
             headers["User-Agent"] = self.user_agent
         if since:
-            headers["If-Modified-Since"] = self._format_since(since)
+            headers["If-Modified-Since"] = since
         request = requests.Request("GET", url, auth=self.oauth,
                                    headers=headers, params=params)
         response = self.session.send(request.prepare())


### PR DESCRIPTION
The streams that used the `since` query parameter for bookmarking were
broken and performing a full sync each run. The `_format_since` function
was copied from the pyxero library:
https://github.com/freakboy3742/pyxero/blob/2ef5e35c0bb3c39977d9eccb79aba8ce41179f1a/xero/basemanager.py#L292-L297
but is not correct, at least in our case. Maybe it works in that library
for some reason specific to the way the library works.

With this change I tested using the `since` parameter with streams:

- bank_transactions
- contacts
- invoices
- overpayments
- prepayments
- accounts
- items
- payments

And confirmed they all work now.