### PR TITLE
Add IsNonRecoverable field to schema

### DIFF
--- a/tap_xero/schemas/tax_rates.json
+++ b/tap_xero/schemas/tax_rates.json
@@ -38,6 +38,12 @@
               "boolean"
             ]
           },
+          "IsNonRecoverable": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
           "Rate": {
             "type": [
               "null",


### PR DESCRIPTION
Xero must have added this field at some point - it is causing the tap to fail for this table.

Testing: I selected just the `tax_rates` table and synced into `target-stitch --dry-run`. Before this change got an error on that field, after it was just fine.