### PR TITLE
Fix linked transactions stream

### DIFF
--- a/tap_xero/streams.py
+++ b/tap_xero/streams.py
@@ -3,6 +3,7 @@ import singer
 from singer import metrics
 from singer.utils import strftime
 import backoff
+import pendulum
 from . import credentials
 from . import transform
 
@@ -140,7 +141,7 @@ class LinkedTransactions(Stream):
             filter_options = {"page": curr_page_num}
             raw_records = _make_request(ctx, self.tap_stream_id, filter_options)
             records = [x for x in raw_records
-                       if x["UpdatedDateUTC"] >= strftime(start)]
+                       if pendulum.parse(x["UpdatedDateUTC"]) >= pendulum.parse(start)]
             if records:
                 self.write_records(records)
                 max_updated = records[-1]["UpdatedDateUTC"]


### PR DESCRIPTION
This stream is broken due to the singer `strftime` not accepting strings. Likely this worked before upgrading the library version but I did not test this particular stream since updating.

I just updated the test Xero account to have one linked transaction in order to test the behavior.

I am using pendulum.parse here because I am essentially trying to make sure to compare apples to apples. The `start` string could be in a variety of formats.