### PR TITLE
Fix PaymentTerms schema in contacts

### DIFF
--- a/tap_xero/schemas/contacts.json
+++ b/tap_xero/schemas/contacts.json
@@ -212,10 +212,7 @@
       ]
     },
     "PaymentTerms": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "$ref": "payment_terms"
     },
     "ContactGroups": {
       "items": {
@@ -357,7 +354,8 @@
     "branding_themes",
     "tracking_categories",
     "validation_errors",
-    "attachments"
+    "attachments",
+    "payment_terms"
   ],
   "additionalProperties": false
 }

--- a/tap_xero/schemas/organisations.json
+++ b/tap_xero/schemas/organisations.json
@@ -208,60 +208,13 @@
       }
     },
     "PaymentTerms": {
-      "type": [
-        "null",
-        "object"
-      ],
-      "properties": {
-        "Sales": {
-          "type": [
-            "null",
-            "object"
-          ],
-          "properties": {
-            "Day": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "Type": {
-              "type": [
-                "null",
-                "string"
-              ]
-            }
-          },
-          "additionalProperties": false
-        },
-        "Bills": {
-          "type": [
-            "null",
-            "object"
-          ],
-          "properties": {
-            "Day": {
-              "type": [
-                "null",
-                "integer"
-              ]
-            },
-            "Type": {
-              "type": [
-                "null",
-                "string"
-              ]
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
+      "$ref": "payment_terms"
     }
   },
   "tap_schema_dependencies": [
     "addresses",
-    "phones"
+    "phones",
+    "payment_terms"
   ],
   "additionalProperties": false
 }

--- a/tap_xero/schemas/payment_terms.json
+++ b/tap_xero/schemas/payment_terms.json
@@ -1,0 +1,51 @@
+{
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+    "Sales": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "Day": {
+          "type": [
+            "null",
+            "integer"
+            ]
+        },
+        "Type": {
+          "type": [
+            "null",
+            "string"
+            ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Bills": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "Day": {
+          "type": [
+            "null",
+            "integer"
+            ]
+        },
+        "Type": {
+          "type": [
+            "null",
+            "string"
+            ]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
Fixes #29 

The `PaymentTerms` key in the `contacts` endpoint was set up as a string where it is really an object. I modified the test account to have contacts with payment terms set up to confirm the behavior. After this change the schema validates properly.

I also tested the organisations stream still works properly and made sure I was testing using an organization with payment terms.