### PR TITLE
Add DueDate(String) to credit_notes schema

### DIFF
--- a/tap_xero/schemas/credit_notes.json
+++ b/tap_xero/schemas/credit_notes.json
@@ -20,6 +20,20 @@
         "string"
       ]
     },
+    "DueDate": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "DueDateString": {
+      "format": "date-time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "Status": {
       "type": [
         "null",


### PR DESCRIPTION
Fixes #33 

I was unable to actually reproduce the issue. I fiddled with credit notes in the Xero UI but I could not find a way to add a due date to them. This PR could be incorrect if the DueDate property is not directly on the credit note, but instead one of its sub-schemas. I will continue trying to reproduce.

