### PR TITLE
Change CurrencyRate field to have extra decimal point

### DIFF
--- a/tap_xero/schemas/bank_transfers.json
+++ b/tap_xero/schemas/bank_transfers.json
@@ -47,7 +47,7 @@
       ],
       "minimum": -1e+33,
       "maximum": 1e+33,
-      "multipleOf": 1e-05,
+      "multipleOf": 1e-06,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },

--- a/tap_xero/schemas/credit_notes.json
+++ b/tap_xero/schemas/credit_notes.json
@@ -135,7 +135,7 @@
       ],
       "minimum": -1e+33,
       "maximum": 1e+33,
-      "multipleOf": 1e-05,
+      "multipleOf": 1e-06,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },

--- a/tap_xero/schemas/invoices.json
+++ b/tap_xero/schemas/invoices.json
@@ -112,7 +112,7 @@
       ],
       "minimum": -1e+33,
       "maximum": 1e+33,
-      "multipleOf": 1e-05,
+      "multipleOf": 1e-06,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },

--- a/tap_xero/schemas/nested_invoice.json
+++ b/tap_xero/schemas/nested_invoice.json
@@ -112,7 +112,7 @@
       ],
       "minimum": -1e+33,
       "maximum": 1e+33,
-      "multipleOf": 1e-05,
+      "multipleOf": 1e-06,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },

--- a/tap_xero/schemas/overpayments.json
+++ b/tap_xero/schemas/overpayments.json
@@ -110,7 +110,7 @@
       ],
       "minimum": -1e+33,
       "maximum": 1e+33,
-      "multipleOf": 1e-05,
+      "multipleOf": 1e-06,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },

--- a/tap_xero/schemas/payments.json
+++ b/tap_xero/schemas/payments.json
@@ -18,7 +18,7 @@
       ],
       "minimum": -1e+33,
       "maximum": 1e+33,
-      "multipleOf": 1e-05,
+      "multipleOf": 1e-06,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },

--- a/tap_xero/schemas/prepayments.json
+++ b/tap_xero/schemas/prepayments.json
@@ -88,7 +88,7 @@
       ],
       "minimum": -1e+33,
       "maximum": 1e+33,
-      "multipleOf": 1e-05,
+      "multipleOf": 1e-06,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },

--- a/tap_xero/schemas/purchase_orders.json
+++ b/tap_xero/schemas/purchase_orders.json
@@ -115,7 +115,7 @@
       ],
       "minimum": -1e+33,
       "maximum": 1e+33,
-      "multipleOf": 1e-05,
+      "multipleOf": 1e-06,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },


### PR DESCRIPTION
There was an instance of data from Xero containing a CurrencyRate with 6 decimal places. This commit changes to JSON schema to reflect this.

Going with 6 decimal places is supported also by the example responses in the [docs](https://developer.xero.com/documentation/api/invoices)

```
        "CurrencyRate": "1.000000"
```

I am unable to test this, however, because the test account doesn't have support for multi-currency invoices. This feature is only available in premium accounts.