### PR TITLE
Fix formatting of overpayments and prepayments

### DIFF
--- a/tap_xero/schemas/overpayments.json
+++ b/tap_xero/schemas/overpayments.json
@@ -143,6 +143,12 @@
         "$ref": "payments"
       }
     },
+    "Reference": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "HasAttachments": {
       "type": [
         "null",

--- a/tap_xero/streams.py
+++ b/tap_xero/streams.py
@@ -169,8 +169,8 @@ all_streams = [
     PaginatedStream("credit_notes", ["CreditNoteID"], transform.format_credit_notes),
     PaginatedStream("invoices", ["InvoiceID"]),
     PaginatedStream("manual_journals", ["ManualJournalID"]),
-    PaginatedStream("overpayments", ["OverpaymentID"]),
-    PaginatedStream("prepayments", ["PrepaymentID"]),
+    PaginatedStream("overpayments", ["OverpaymentID"], transform.format_over_pre_payments),
+    PaginatedStream("prepayments", ["PrepaymentID"], transform.format_over_pre_payments),
     PaginatedStream("purchase_orders", ["PurchaseOrderID"]),
 
     # JOURNALS STREAM

--- a/tap_xero/transform.py
+++ b/tap_xero/transform.py
@@ -28,6 +28,11 @@ def format_payments(payments):
         _format_nested_invoice(invoice)
 
 
+def format_over_pre_payments(over_pre_payments):
+    for payment in over_pre_payments:
+        _format_allocations(payment.get("Allocations", []))
+
+
 def strip_warnings(records):
     for record in records:
         record.pop("Warnings", None)


### PR DESCRIPTION
These streams, like credit notes and payments, have some crazy nesting.
Early in the tap development we decided to strip out invoices when they
get very nested, because otherwise the schemas will be recursive or have
a significant amount of duplication. This change strips out those nested
fields like the other streams.

Fixes #32

I did not have a way to test the prepayments stream. I cannot find a way
to make a prepayment - it looks like you have to first connect a bank
account. I did, however, make a sample overpayment and confirm the
schema matches it.