### PR TITLE
Fix Allocations.AppliedAmount in JSON schema

### DIFF
--- a/tap_xero/schemas/prepayments.json
+++ b/tap_xero/schemas/prepayments.json
@@ -10,6 +10,12 @@
         "string"
       ]
     },
+    "ID": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "Contact": {
       "$ref": "contacts"
     },
@@ -99,6 +105,17 @@
       ]
     },
     "RemainingCredit": {
+      "type": [
+        "null",
+        "number"
+      ],
+      "minimum": -1e+33,
+      "maximum": 1e+33,
+      "multipleOf": 1e-05,
+      "exclusiveMinimum": true,
+      "exclusiveMaximum": true
+    },
+    "AppliedAmount": {
       "type": [
         "null",
         "number"


### PR DESCRIPTION
To match documentation in https://developer.xero.com/documentation/api/prepayments

Fixes #42, hopefully. "ID" isn't mentioned in the API docs, although it's part of the error message on that ticket.

Please note that I haven't tested this as I'm not running tap-xero directly.