### PR TITLE
Fix missing return statement

### DIFF
--- a/tap_xero/streams.py
+++ b/tap_xero/streams.py
@@ -38,14 +38,14 @@ def _make_request(ctx, tap_stream_id, filter_options=None, attempts=0):
     except XeroUnauthorized:
         if attempts == 1:
             raise Exception("Received Not Authorized response after credential refresh.")
-        attempts += 1
         new_config = credentials.refresh(ctx.config)
         ctx.client.update_credentials(new_config)
-        _make_request(ctx, tap_stream_id, filter_options, attempts)
+        return _make_request(ctx, tap_stream_id, filter_options, attempts + 1)
     except HTTPError as e:
         if e.response.status_code == 503:
             raise RateLimitException()
         raise
+    assert False
 
 
 class Stream(object):


### PR DESCRIPTION
I believe this will fix #50 - That issue shows there is a case where the streams.py code is receiving `None` instead of a list for the linked transactions stream. The Xero API has been good, so far as I have seen, about always returning lists. I scanned the code and noticed this spot where the _make_request function is not returning its results after a re-authorization. This is most likely the culprit of the bug.

I put that assertion in there so that there will be a more obvious failure if the _make_request function ever gets to the end of the function without explicitly returning something.