### PR TITLE
Fix/handle weird epoch timings

### DIFF
--- a/tap_xero/__init__.py
+++ b/tap_xero/__init__.py
@@ -94,7 +94,7 @@ def init_credentials(config):
                 except XeroUnauthorized as ex:
                     raise BadCredsException(BAD_CREDS_MESSAGE) from ex
             else:
-                raise BadCredsException(BAD_CREDS_MESSAGE) from ex
+                raise BadCredsException(BAD_CREDS_MESSAGE) from e
 
     return config
 

--- a/tap_xero/streams.py
+++ b/tap_xero/streams.py
@@ -176,7 +176,7 @@ all_streams = [
     PaginatedStream("bank_transactions", ["BankTransactionID"]),
     PaginatedStream("contacts", ["ContactID"], format_fn=transform.format_contacts),
     PaginatedStream("credit_notes", ["CreditNoteID"], format_fn=transform.format_credit_notes),
-    PaginatedStream("invoices", ["InvoiceID"]),
+    PaginatedStream("invoices", ["InvoiceID"], format_fn=transform.format_invoices),
     PaginatedStream("manual_journals", ["ManualJournalID"]),
     PaginatedStream("overpayments", ["OverpaymentID"], format_fn=transform.format_over_pre_payments),
     PaginatedStream("prepayments", ["PrepaymentID"], format_fn=transform.format_over_pre_payments),

--- a/tap_xero/transform.py
+++ b/tap_xero/transform.py
@@ -51,3 +51,13 @@ def format_contacts(contacts):
     strip_warnings(contacts)
     for contact in contacts:
         format_contact_groups(contact["ContactGroups"])
+
+def format_invoices(invoices):
+    # NB: Xero sometimes formats the Date as '/Date(0+0000)/' to indicate
+    # it is 0 milliseconds from the unix epoch. Convert this to a datetime
+    # that will be accepted by the transformer. This should not cause
+    # inconsitencies because the 'Date' is normally returned as an iso8601
+    # string and this edge case causes it to be returned differently
+    for invoice in invoices:
+        if invoice.get('Date') == '/Date(0+0000)/':
+            invoice['Date'] = '1970-01-01T00:00:00.000000Z'


### PR DESCRIPTION
# Description of change
Xero formats the 'Date' key under invoices as `'/Date(0+0000)/'` when an invoice has been voided. This causes the transformer to fail because it does not match the schema for a datetime. In this edge case convert the date to the normal iso8601 string it typically is formatted as.

# Manual QA steps
 - Ran this on a Xero connection that was failing at this invoice, confirmed it works and the transformer is happy.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
