### PR TITLE
Convert '/Date(0+0000)/' into '1970-01-01T00:00:00.000000Z' for JournalDate

### DIFF
--- a/tap_xero/streams.py
+++ b/tap_xero/streams.py
@@ -120,6 +120,7 @@ class Journals(Stream):
             filter_options = {"offset": journal_number}
             records = _make_request(ctx, self.tap_stream_id, filter_options)
             if records:
+                self.format_fn(records)
                 self.write_records(records, ctx)
                 journal_number = records[-1][self.bookmark_key]
             if not records or len(records) < FULL_PAGE_SIZE:
@@ -184,7 +185,7 @@ all_streams = [
 
     # JOURNALS STREAM
     # This endpoint is paginated, but in its own special snowflake way.
-    Journals("journals", ["JournalID"], bookmark_key="JournalNumber"),
+    Journals("journals", ["JournalID"], bookmark_key="JournalNumber", format_fn=transform.format_journals),
 
     # NON-PAGINATED STREAMS
     # These endpoints do not support pagination, but do support the Modified At

--- a/tap_xero/transform.py
+++ b/tap_xero/transform.py
@@ -61,3 +61,15 @@ def format_invoices(invoices):
     for invoice in invoices:
         if invoice.get('Date') == '/Date(0+0000)/':
             invoice['Date'] = '1970-01-01T00:00:00.000000Z'
+
+
+def format_journals(journals):
+    # NB: Xero sometimes formats the JournalDate as '/Date(0+0000)/' to
+    # indicate it is 0 milliseconds from the unix epoch. Convert this to a
+    # datetime that will be accepted by the transformer. This should not
+    # cause inconsitencies because the 'Date' is normally returned as an
+    # iso8601 string and this edge case causes it to be returned
+    # differently
+    for journal in journals:
+        if journal.get('JournalDate') == '/Date(0+0000)/':
+            journal['JournalDate'] = '1970-01-01T00:00:00.000000Z'


### PR DESCRIPTION
# Description of change
Similar to #62, Xero formats dates at the epoch as `'/Date(0+0000)/'`, but the transformer does not accept this as a datetime. Convert this date to an ISO8601 string.

# Manual QA steps
 - Ran this on a connection that was running into this issue for journal date. It works with the change and does not without it.
 
# Risks
 - There may be other places in Xero where `'/Date(0+0000)/'` is returned
 
# Rollback steps
 - revert this branch
