### PR TITLE
Bump to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.0
+  * Switch from OAuth1 to OAuth2. This will no longer work with OAuth1 credentials and any users will need to [migrate their tokens](https://developer.xero.com/documentation/oauth2/migrate) [#66](https://github.com/singer-io/tap-xero/pull/66)
+
 ## 1.0.4
   * Add handling for date formatting on JournalDate for when Xero returns the date as '/Date(0+0000)/' [#64](https://github.com/singer-io/tap-xero/pull/64)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-xero",
-      version="1.0.4",
+      version="2.0.0",
       description="Singer.io tap for extracting data from the Xero API",
       author="Stitch",
       url="http://singer.io",


### PR DESCRIPTION
# Description of change
Bump to v2.0.0

# Manual QA steps
 - 
 
# Risks
 - There are changes to required config keys and OAuth credentials must be migrated to OAuth2 or the tap will not be able to authenticate.
 
# Rollback steps
 - revert this branch
