### PR TITLE
Ensure fields are formatted like datetimes before converting to datetime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,11 @@ jobs:
             source /usr/local/share/virtualenvs/tap-xero/bin/activate
             pylint tap_xero --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace'
       - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-xero/bin/activate
+            nosetests tests/unittests/
+      - run:
           name: 'Integration Tests'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(name="tap-xero",
       extras_require={
           'dev': [
               'ipdb',
-              'pylint'
+              'pylint',
+              'nose'
           ]
       },
       entry_points="""

--- a/tap_xero/client.py
+++ b/tap_xero/client.py
@@ -19,10 +19,16 @@ def parse_date(value):
     pattern = r'Date\((\d+)([-+])?(\d+)?\)'
     match = re.search(pattern, value)
 
+    iso8601pattern = r'((\d{4})-([0-2]\d)-0?([0-3]\d)T([0-5]\d):([0-5]\d):([0-6]\d))'
+
     if not match:
-        try:
-            return strptime_to_utc(value)
-        except Exception:
+        iso8601match = re.search(iso8601pattern, value)
+        if iso8601match:
+            try:
+                return strptime_to_utc(value)
+            except:
+                return None
+        else:
             return None
 
     millis_timestamp, offset_sign, offset = match.groups()

--- a/tap_xero/client.py
+++ b/tap_xero/client.py
@@ -26,7 +26,7 @@ def parse_date(value):
         if iso8601match:
             try:
                 return strptime_to_utc(value)
-            except:
+            except Exception:
                 return None
         else:
             return None

--- a/tests/unittests/test_datetime_parsing.py
+++ b/tests/unittests/test_datetime_parsing.py
@@ -1,0 +1,54 @@
+from tap_xero.client import parse_date
+from singer.utils import strptime_to_utc
+import unittest
+import datetime
+
+class TestDatetimeParsing(unittest.TestCase):
+
+    def test_normal_datetimes(self):
+        dates = [
+            '2020-10-20T12:30:00Z',
+            '2020-01-02T16:30:00Z',
+            '2020-01-01T12:30:00+0',
+        ]
+
+        parsed_dates = [parse_date(x) for x in dates]
+
+        expected_dates = [
+            strptime_to_utc('2020-10-20T12:30:00Z'),
+            strptime_to_utc('2020-01-02T16:30:00Z'),
+            strptime_to_utc('2020-01-01T12:30:00+0'),
+        ]
+
+        self.assertEquals(parsed_dates, expected_dates)
+
+    def test_epoch_datetimes(self):
+        dates = [
+            '/Date(1603895333000+0000)/',
+            '/Date(814890533000+0000)/',
+            '/Date(1130509733000+0000)/',
+        ]
+
+        parsed_dates = [parse_date(x) for x in dates]
+
+        expected_dates = [
+            datetime.datetime(2020, 10, 28, 14, 28, 53),
+            datetime.datetime(1995, 10, 28, 14, 28, 53),
+            datetime.datetime(2005, 10, 28, 14, 28, 53),
+        ]
+
+        self.assertEquals(parsed_dates, expected_dates)
+
+    def test_not_datetimes(self):
+        dates = [
+            '1023',
+            'abcsdf',
+            '0020',
+            '0023'
+        ]
+
+        parsed_dates = [parse_date(x) for x in dates]
+
+        expected_dates = [None, None, None, None]
+
+        self.assertEquals(parsed_dates, expected_dates)


### PR DESCRIPTION
# Description of change
Ensure fields are formatted as a datetime before attempting to convert them to a datetime.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
