### PR TITLE
allow negative datetimes in parse_date

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: |
             python3 -mvenv /usr/local/share/virtualenvs/tap-xero
             source /usr/local/share/virtualenvs/tap-xero/bin/activate
-            pip install -U 'pip<19.2' setuptools
+            pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[dev]
       - run:
           name: 'JSON Validator'

--- a/tap_xero/client.py
+++ b/tap_xero/client.py
@@ -16,7 +16,7 @@ def parse_date(value):
     # Xero datetimes can be .NET JSON date strings which look like
     # "/Date(1419937200000+0000)/"
     # https://developer.xero.com/documentation/api/requests-and-responses
-    pattern = r'Date\((\d+)([-+])?(\d+)?\)'
+    pattern = r'Date\((\-?\d+)([-+])?(\d+)?\)'
     match = re.search(pattern, value)
 
     iso8601pattern = r'((\d{4})-([0-2]\d)-0?([0-3]\d)T([0-5]\d):([0-5]\d):([0-6]\d))'

--- a/tests/unittests/test_datetime_parsing.py
+++ b/tests/unittests/test_datetime_parsing.py
@@ -27,6 +27,7 @@ class TestDatetimeParsing(unittest.TestCase):
             '/Date(1603895333000+0000)/',
             '/Date(814890533000+0000)/',
             '/Date(1130509733000+0000)/',
+            '/Date(-1565568000000+0000)/',
         ]
 
         parsed_dates = [parse_date(x) for x in dates]
@@ -35,6 +36,7 @@ class TestDatetimeParsing(unittest.TestCase):
             datetime.datetime(2020, 10, 28, 14, 28, 53),
             datetime.datetime(1995, 10, 28, 14, 28, 53),
             datetime.datetime(2005, 10, 28, 14, 28, 53),
+            datetime.datetime(1920, 5, 23, 00, 00, 00),
         ]
 
         self.assertEquals(parsed_dates, expected_dates)


### PR DESCRIPTION
# Description of change
Changes parse_date in client.py to accept negative dates. Also updates unit tests

# Manual QA steps
 - ran unit tests
 
# Risks
 - low
 
# Rollback steps
 - revert this branch
