### PR TITLE
v2.0.4: Explicitly check for date while parsing so that `datetime` does not match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.4
+  * In json parsing hook, explicitly check for `date` type values to add 0 hh:mm:ss to so that the parser avoids truncating `datetime` objects [#79](https://github.com/singer-io/tap-xero/pull/79)
+
 ## 2.0.3
   * Switching the Payments stream to use the PaginatedStream class as that API endpoint can paginate using the "page" query param [#76](https://github.com/singer-io/tap-xero/pull/76)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-xero",
-      version="2.0.3",
+      version="2.0.4",
       description="Singer.io tap for extracting data from the Xero API",
       author="Stitch",
       url="http://singer.io",

--- a/tap_xero/client.py
+++ b/tap_xero/client.py
@@ -55,7 +55,8 @@ def _json_load_object_hook(_dict):
         if isinstance(value, six.string_types):
             value = parse_date(value)
             if value:
-                if type(value) is date:
+                # NB> Pylint disabled because, regardless of idioms, this is more explicit than isinstance.
+                if type(value) is date: # pylint: disable=unidiomatic-typecheck
                     value = datetime.combine(value, time.min)
                 value = value.replace(tzinfo=pytz.UTC)
                 _dict[key] = strftime(value)

--- a/tap_xero/client.py
+++ b/tap_xero/client.py
@@ -55,7 +55,7 @@ def _json_load_object_hook(_dict):
         if isinstance(value, six.string_types):
             value = parse_date(value)
             if value:
-                if isinstance(value, date):
+                if type(value) is date:
                     value = datetime.combine(value, time.min)
                 value = value.replace(tzinfo=pytz.UTC)
                 _dict[key] = strftime(value)


### PR DESCRIPTION
# Description of change
While debugging a separate issue, I noticed that datetimes of the format `"\/Date(1419937200000+0000)\/"` as documented by Xero [here](https://developer.xero.com/documentation/api/requests-and-responses) were being truncated to `date` only.

The root of the issue was that `isinstance(value, date)` also matches `datetime` data types, so both were going down that path.

This PR makes the check _explicitly_ for `date` only to avoid any conflict.

# Manual QA steps
 - Ran through this in a PDB session and it worked out for both date and datetime

### Testing Notes

Original behavior
```
ipdb> value
datetime.datetime(2020, 5, 13, 14, 20, 6, 547000)
ipdb> isinstance(value, date)
True
ipdb> isinstance(value, datetime)
True
ipdb> testdt = date(1976,10,10)
ipdb> isinstance(testdt, datetime)
False
ipdb> isinstance(testdt, date)
True
```

New Behavior
```
ipdb> testdt = date(1976,10,10)
ipdb> type(testdt) is date
True
ipdb> type(testdt) is datetime
False
ipdb> testdtt = datetime(1976,10,10,1,2,3)
ipdb> type(testdtt) is datetime
True
ipdb> type(testdtt) is date
False
```
 
# Risks
 - Low, it's a relatively straightforward change, albeit a subtle cause.
 
# Rollback steps
 - revert this branch, bump patch version, re-release
