### PR TITLE
TDL-590: Added retry logic on JSON decoder error in the filter function

### DIFF
--- a/tap_xero/client.py
+++ b/tap_xero/client.py
@@ -8,6 +8,7 @@ import requests
 from singer.utils import strftime, strptime_to_utc
 import six
 import pytz
+import backoff
 
 BASE_URL = "https://api.xero.com/api.xro/2.0"
 
@@ -96,6 +97,9 @@ class XeroClient():
         self.access_token = resp["access_token"]
         self.tenant_id = config['tenant_id']
 
+    @backoff.on_exception(backoff.expo,
+                          json.decoder.JSONDecodeError,
+                          max_tries=3)
     def filter(self, tap_stream_id, since=None, **params):
         xero_resource_name = tap_stream_id.title().replace("_", "")
         url = join(BASE_URL, xero_resource_name)

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -1,0 +1,73 @@
+import tap_xero.client as client_
+import unittest
+import requests
+from unittest import mock
+import decimal
+import json
+
+json_decode_error_str = '{\'key\': \'value\'}'
+
+def mocked_session(*args, **kwargs):
+    class Mocksession:
+        def __init__(self, json_data, status_code):
+            self.text = json_data
+            self.status_code = status_code
+        
+        def raise_for_status(self):
+            return self.status_code
+        
+    return Mocksession(args[0], 200)
+
+def mocked_request(*args, **kwargs):
+    class Mockresponse:
+        def __init__(self, resp):
+            self.json_data = resp
+
+        def prepare(self):
+            return self.json_data
+
+    return Mockresponse(json_decode_error_str)
+
+class TestFilterFunExceptionHandling(unittest.TestCase):
+    """
+    Test cases to verify if the exceptions are handled as expected while communicating with Xero Environment 
+    """
+
+    @mock.patch('requests.Session.send', side_effect=mocked_session)
+    @mock.patch('requests.Request', side_effect=mocked_request)
+    def test_json_decode_exception(self, mocked_session, mocked_request):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+        try:
+            filter_func_exec = xero_client.filter(tap_stream_id)
+        except json.decoder.JSONDecodeError as e:
+            pass
+
+        self.assertEqual(mocked_request.call_count, 3)
+        self.assertEqual(mocked_session.call_count, 3)
+
+    @mock.patch('requests.Session.send', side_effect=mocked_session)
+    @mock.patch('requests.Request', side_effect=mocked_request)
+    def test_normal_filter_execution(self, mocked_session, mocked_request):
+        config = {}
+        tap_stream_id = "contacts"
+
+        global json_decode_error_str
+        json_decode_error_str = '{"Contacts": "value"}'
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+        try:
+            filter_func_exec = xero_client.filter(tap_stream_id)
+        except json.decoder.JSONDecodeError as e:
+            pass
+
+        self.assertEqual(mocked_request.call_count, 1)
+        self.assertEqual(mocked_session.call_count, 1)
+
+


### PR DESCRIPTION
# Description of change
TDL-590: Add retry logic to client "filter" function so it can be retried on error

# Manual QA steps
 - Wasn't able to reproduce in the LIVE env. However, added an invalid JSON in the function and made sure that the function retries 3 times before halting the execution
 
# Risks
 - No Risks
 
# Rollback steps
 - revert this branch

# Automated tests
 - Added a unit test for a negative scenario and a positive scenario
