### PR TITLE
Add backoff mechanism for 429, throw friendly message on REST API error and validate authorization during discovery mode

### DIFF
--- a/tap_xero/__init__.py
+++ b/tap_xero/__init__.py
@@ -68,7 +68,7 @@ def ensure_credentials_are_valid(config):
     XeroClient(config).filter("currencies")
 
 def discover(ctx):
-    ctx.refresh_credentials()
+    ctx.check_platform_access()
     catalog = Catalog([])
     for stream in streams_.all_streams:
         schema_dict = load_schema(stream.tap_stream_id)

--- a/tap_xero/client.py
+++ b/tap_xero/client.py
@@ -165,11 +165,10 @@ class XeroClient():
             self.tenant_id = config['tenant_id']
 
 
-    def check_platform_access(self, config, config_path, check_authentication=True):
+    def check_platform_access(self, config, config_path):
 
         # Validating the authentication of the provided configuration
-        if check_authentication:
-            self.refresh_credentials(config, config_path)
+        self.refresh_credentials(config, config_path)
 
         headers = {
             "Authorization": "Bearer " + self.access_token,

--- a/tap_xero/client.py
+++ b/tap_xero/client.py
@@ -110,7 +110,7 @@ class XeroClient():
         self.access_token = resp["access_token"]
         self.tenant_id = config['tenant_id']
 
-    @backoff.on_exception(backoff.expo, XeroTooManyError, max_tries=3)
+    @backoff.on_exception(backoff.expo, XeroTooManyError, max_tries=3, factor=2)
     def filter(self, tap_stream_id, since=None, **params):
         xero_resource_name = tap_stream_id.title().replace("_", "")
         url = join(BASE_URL, xero_resource_name)

--- a/tap_xero/client.py
+++ b/tap_xero/client.py
@@ -185,8 +185,7 @@ class XeroClient():
             raise_for_error(response)
 
 
-    @backoff.on_exception(backoff.expo,json.decoder.JSONDecodeError,max_tries=3)
-    @backoff.on_exception(backoff.expo, XeroTooManyError, max_tries=3, factor=2)
+    @backoff.on_exception(backoff.expo, (json.decoder.JSONDecodeError, XeroTooManyError), max_tries=3)
     def filter(self, tap_stream_id, since=None, **params):
         xero_resource_name = tap_stream_id.title().replace("_", "")
         url = join(BASE_URL, xero_resource_name)

--- a/tap_xero/context.py
+++ b/tap_xero/context.py
@@ -15,7 +15,7 @@ class Context():
         self.client.refresh_credentials(self.config, self.config_path)
 
     def check_platform_access(self):
-        self.client.check_platform_access(self.config, self.config_path, check_authentication=True)
+        self.client.check_platform_access(self.config, self.config_path)
 
     def get_bookmark(self, path):
         return bks_.get_bookmark(self.state, *path)

--- a/tap_xero/context.py
+++ b/tap_xero/context.py
@@ -14,6 +14,9 @@ class Context():
     def refresh_credentials(self):
         self.client.refresh_credentials(self.config, self.config_path)
 
+    def check_platform_access(self):
+        self.client.check_platform_access(self.config, self.config_path, check_authentication=True)
+
     def get_bookmark(self, path):
         return bks_.get_bookmark(self.state, *path)
 

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -1,0 +1,93 @@
+import tap_xero.client as client_
+import unittest
+import requests
+from unittest import mock
+import decimal
+import json
+
+
+def mocked_session(*args, **kwargs):
+    class Mocksession:
+        def __init__(self, json_data, status_code, content, headers, raise_error):
+            self.text = json_data
+            self.status_code = status_code
+            self.raise_error = raise_error
+            if headers:
+                self.headers = headers
+
+        def raise_for_status(self):
+            if not raise_error:
+                return self.status_code
+
+            raise requests.HTTPError("sample message")
+
+    arguments_to_session = args[0]
+
+    json_data = arguments_to_session[0]
+    status_code = arguments_to_session[1]
+    content = arguments_to_session[2]
+    headers = arguments_to_session[3]
+    raise_error = arguments_to_session[4]
+    return Mocksession(json_data, status_code, content, headers, raise_error)
+
+
+class Mockresponse:
+    def __init__(self, resp, status_code, content=[], headers=None, raise_error=False):
+        self.json_data = resp
+        self.status_code = status_code
+        self.content = content
+        self.headers = headers
+        self.raise_error = raise_error
+
+    def prepare(self):
+        return (self.json_data, self.status_code, self.content, self.headers, self.raise_error)
+
+
+def mocked_failed_429_request(*args, **kwargs):
+    json_decode_str = ''
+    headers = {"Retry-After": 10}
+    return Mockresponse(json_decode_str, 429, headers=headers, raise_error=True)
+
+
+class TestFilterFunExceptionHandling(unittest.TestCase):
+    """
+    Test cases to verify if the exceptions are handled as expected while communicating with Xero Environment 
+    """
+
+    @mock.patch('requests.Session.send', side_effect=mocked_session)
+    @mock.patch('requests.Request', side_effect=mocked_failed_429_request)
+    def test_too_many_requests_custom_exception(self, mocked_session, mocked_failed_429_request):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            # Verifying if the custom exception 'XeroTooManyError' is raised on receiving status code 429
+            self.assertRaises(client_.XeroTooManyError, xero_client.filter(tap_stream_id))
+        except (requests.HTTPError, client_.XeroTooManyError) as e:
+            expected_error_message = "Error: Too Many Requests. Please retry after 10 seconds"
+            
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            pass
+
+
+    @mock.patch('requests.Session.send', side_effect=mocked_session)
+    @mock.patch('requests.Request', side_effect=mocked_failed_429_request)
+    def test_too_many_requests_backoff_behavior(self, mocked_session, mocked_failed_429_request):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+        try:
+            filter_func_exec = xero_client.filter(tap_stream_id)
+        except (requests.HTTPError, client_.XeroTooManyError) as e:
+            pass
+
+        self.assertEqual(mocked_failed_429_request.call_count, 3)
+        self.assertEqual(mocked_session.call_count, 3)


### PR DESCRIPTION
# Description of change
Since below JIRAs have interdependent code, I have added code for all these JIRAs in this single PR
 - TDL-593: Added backoff mechanism to retry API execution on encountering 429 status code
 - TDL-594: Added support of checking the authentication and authorization of the credentials provided during discovery mode
 - TDL-648: Added custom exceptions to throw friendly message on permission errors and other failure status codes

# Manual QA steps
 - Raised 429 status code in the local environment and verified if the function is retrying for this scenario
 - Verified the execution of normal scenario (having status code 200) if it is getting affected because of adding backoff behavior
 
# Risks
 - If Day Limit is reached, retrying might not be able to collect data until API resumes providing the response.
 - Link: https://developer.xero.com/documentation/oauth2/limits
 
# Rollback steps
 - revert this branch
