### PR TITLE
Increase the allowable precision in the CurrencyRate field

### DIFF
--- a/tap_xero/schemas/bank_transactions.json
+++ b/tap_xero/schemas/bank_transactions.json
@@ -64,7 +64,7 @@
       ],
       "minimum": -1e+33,
       "maximum": 1e+33,
-      "multipleOf": 1e-06,
+      "multipleOf": 1e-10,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },

--- a/tap_xero/schemas/bank_transfers.json
+++ b/tap_xero/schemas/bank_transfers.json
@@ -47,7 +47,7 @@
       ],
       "minimum": -1e+33,
       "maximum": 1e+33,
-      "multipleOf": 1e-06,
+      "multipleOf": 1e-10,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },

--- a/tap_xero/schemas/credit_notes.json
+++ b/tap_xero/schemas/credit_notes.json
@@ -149,7 +149,7 @@
       ],
       "minimum": -1e+33,
       "maximum": 1e+33,
-      "multipleOf": 1e-06,
+      "multipleOf": 1e-10,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },

--- a/tap_xero/schemas/invoices.json
+++ b/tap_xero/schemas/invoices.json
@@ -112,7 +112,7 @@
       ],
       "minimum": -1e+33,
       "maximum": 1e+33,
-      "multipleOf": 1e-06,
+      "multipleOf": 1e-10,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },

--- a/tap_xero/schemas/nested_invoice.json
+++ b/tap_xero/schemas/nested_invoice.json
@@ -112,7 +112,7 @@
       ],
       "minimum": -1e+33,
       "maximum": 1e+33,
-      "multipleOf": 1e-06,
+      "multipleOf": 1e-10,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },

--- a/tap_xero/schemas/overpayments.json
+++ b/tap_xero/schemas/overpayments.json
@@ -110,7 +110,7 @@
       ],
       "minimum": -1e+33,
       "maximum": 1e+33,
-      "multipleOf": 1e-06,
+      "multipleOf": 1e-10,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },

--- a/tap_xero/schemas/payments.json
+++ b/tap_xero/schemas/payments.json
@@ -18,7 +18,7 @@
       ],
       "minimum": -1e+33,
       "maximum": 1e+33,
-      "multipleOf": 1e-06,
+      "multipleOf": 1e-10,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },

--- a/tap_xero/schemas/prepayments.json
+++ b/tap_xero/schemas/prepayments.json
@@ -94,7 +94,7 @@
       ],
       "minimum": -1e+33,
       "maximum": 1e+33,
-      "multipleOf": 1e-06,
+      "multipleOf": 1e-10,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },

--- a/tap_xero/schemas/purchase_orders.json
+++ b/tap_xero/schemas/purchase_orders.json
@@ -115,7 +115,7 @@
       ],
       "minimum": -1e+33,
       "maximum": 1e+33,
-      "multipleOf": 1e-06,
+      "multipleOf": 1e-10,
       "exclusiveMinimum": true,
       "exclusiveMaximum": true
     },


### PR DESCRIPTION
# Description of change
We encountered a CurrencyRate with 7 decimals of precision.
Increasing the `multipleOf` in the schema for `CurrencyRate` from `1e-06` to `1e-10`.

# Manual QA steps
 - 
 
# Risks
 - Minimal, allowing more precise decimals in the schema should have no impact except to except more values of `CurrencyRate`
 
# Rollback steps
 - revert this branch
