### PR TITLE
Tdl 812 add wait time for rate limit backoff

### DIFF
--- a/tap_xero/client.py
+++ b/tap_xero/client.py
@@ -41,17 +41,27 @@ class XeroNotFoundError(XeroError):
     pass
 
 
+class XeroPreConditionFailedError(XeroError):
+    pass
+
+
 class XeroTooManyError(XeroError):
     pass
 
+
 class XeroTooManyInMinuteError(XeroError):
     pass
+
 
 class XeroInternalError(XeroError):
     pass
 
 
 class XeroNotImplementedError(XeroError):
+    pass
+
+
+class XeroNotAvailableError(XeroError):
     pass
 
 
@@ -72,6 +82,10 @@ ERROR_CODE_EXCEPTION_MAPPING = {
         "raise_exception": XeroNotFoundError,
         "message": "The resource you have specified cannot be found."
     },
+    412: {
+        "raise_exception": XeroPreConditionFailedError,
+        "message": "One or more conditions given in the request header fields were invalid."
+    },
     429: {
         "raise_exception": XeroTooManyError,
         "message": "The API rate limit for your organisation/application pairing has been exceeded"
@@ -83,6 +97,10 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     501: {
         "raise_exception": XeroNotImplementedError,
         "message": "The method you have called has not been implemented."
+    },
+    503: {
+        "raise_exception": XeroNotAvailableError,
+        "message": "API service is currently unavailable."
     }
 }
 

--- a/tap_xero/client.py
+++ b/tap_xero/client.py
@@ -2,6 +2,9 @@ from base64 import b64encode
 import re
 import json
 import decimal
+import sys
+import math
+import singer
 from os.path import join
 from datetime import datetime, date, time, timedelta
 import requests
@@ -10,11 +13,15 @@ import six
 import pytz
 import backoff
 
+LOGGER = singer.get_logger()
+
 BASE_URL = "https://api.xero.com/api.xro/2.0"
 
 
 class XeroError(Exception):
-    pass
+    def __init__(self, message=None, response=None):
+        self.message = message
+        self.response = response
 
 
 class XeroBadRequestError(XeroError):
@@ -36,6 +43,8 @@ class XeroNotFoundError(XeroError):
 class XeroTooManyError(XeroError):
     pass
 
+class XeroTooManyErrorInMinute(XeroError):
+    pass
 
 class XeroInternalError(XeroError):
     pass
@@ -131,6 +140,24 @@ def update_config_file(config, config_path):
     with open(config_path, 'w') as config_file:
         json.dump(config, config_file, indent=2)
 
+def is_not_status_code_fn(status_code):
+    def gen_fn(exc):
+        if getattr(exc, 'response', None) and getattr(exc.response, 'status_code', None) and exc.response.status_code not in status_code:
+            return True
+        # Retry other errors up to the max
+        return False
+    return gen_fn
+
+def retry_after_wait_gen(**kwargs):
+    while True:
+        # This is called in an except block so we can retrieve the exception
+        # and check it.
+        exc_info = sys.exc_info()
+        resp = exc_info[1].response
+        sleep_time_str = resp.headers.get('Retry-After')
+        LOGGER.info("Received 429 -- sleeping for {} seconds".format(sleep_time_str))
+        yield math.floor(float(sleep_time_str))
+
 class XeroClient():
     def __init__(self, config):
         self.session = requests.Session()
@@ -165,6 +192,8 @@ class XeroClient():
             self.tenant_id = config['tenant_id']
 
 
+    @backoff.on_exception(backoff.expo, XeroInternalError, max_tries=3)
+    @backoff.on_exception(retry_after_wait_gen, XeroTooManyErrorInMinute, giveup=is_not_status_code_fn([429]), jitter=None, max_tries=3)
     def check_platform_access(self, config, config_path):
 
         # Validating the authentication of the provided configuration
@@ -185,7 +214,8 @@ class XeroClient():
             raise_for_error(response)
 
 
-    @backoff.on_exception(backoff.expo, (json.decoder.JSONDecodeError, XeroTooManyError), max_tries=3)
+    @backoff.on_exception(backoff.expo, (json.decoder.JSONDecodeError, XeroInternalError), max_tries=3)
+    @backoff.on_exception(retry_after_wait_gen, XeroTooManyErrorInMinute, giveup=is_not_status_code_fn([429]), jitter=None, max_tries=3)
     def filter(self, tap_stream_id, since=None, **params):
         xero_resource_name = tap_stream_id.title().replace("_", "")
         url = join(BASE_URL, xero_resource_name)
@@ -223,6 +253,10 @@ def raise_for_error(resp):
                 resp_headers = resp.headers
                 api_rate_limit_message = ERROR_CODE_EXCEPTION_MAPPING[429]["message"]
                 message = "HTTP-error-code: 429, Error: {}. Please retry after {} seconds".format(api_rate_limit_message, resp_headers.get("Retry-After"))
+
+                #Raise XeroTooManyErrorInMinute exception if minute limit is reached
+                if resp_headers.get("X-Rate-Limit-Problem") == 'minute':
+                    raise XeroTooManyErrorInMinute(message, resp)
             # Handling status code 403 specially since response of API does not contain enough information
             elif error_code in (403, 401):
                 api_message = ERROR_CODE_EXCEPTION_MAPPING[error_code]["message"]
@@ -244,7 +278,7 @@ def raise_for_error(resp):
                                 ))))
 
             exc = ERROR_CODE_EXCEPTION_MAPPING.get(error_code, {}).get("raise_exception", XeroError)
-            raise exc(message) from None
+            raise exc(message, resp) from None
 
         except (ValueError, TypeError):
             raise XeroError(error) from None

--- a/tap_xero/client.py
+++ b/tap_xero/client.py
@@ -193,7 +193,7 @@ class XeroClient():
             self.tenant_id = config['tenant_id']
 
 
-    @backoff.on_exception(backoff.expo, XeroInternalError, max_tries=3)
+    @backoff.on_exception(backoff.expo, (json.decoder.JSONDecodeError, XeroInternalError), max_tries=3)
     @backoff.on_exception(retry_after_wait_gen, XeroTooManyInMinuteError, giveup=is_not_status_code_fn([429]), jitter=None, max_tries=3)
     def check_platform_access(self, config, config_path):
 

--- a/tap_xero/client.py
+++ b/tap_xero/client.py
@@ -174,7 +174,7 @@ def retry_after_wait_gen():
         exc_info = sys.exc_info()
         resp = exc_info[1].response
         sleep_time_str = resp.headers.get('Retry-After')
-        LOGGER.info("Received 429 -- sleeping for %s seconds", sleep_time_str)
+        LOGGER.info("API rate limit exceeded -- sleeping for %s seconds", sleep_time_str)
         yield math.floor(float(sleep_time_str))
 
 class XeroClient():

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -306,9 +306,9 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
         xero_client.tenant_id = "123"
 
         try:
-            # Verifying if the custom exception 'XeroTooManyErrorInMinute' is raised on receiving status code 429 with minute limit exceeded
+            # Verifying if the custom exception 'XeroTooManyInMinuteError' is raised on receiving status code 429 with minute limit exceeded
             filter_func_exec = xero_client.filter(tap_stream_id)
-        except client_.XeroTooManyErrorInMinute as e:
+        except client_.XeroTooManyInMinuteError as e:
             expected_error_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded. Please retry after 5 seconds"
             
             # Verifying the message formed for the custom exception
@@ -344,7 +344,7 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
         xero_client.tenant_id = "123"
         try:
             filter_func_exec = xero_client.filter(tap_stream_id)
-        except (requests.HTTPError, client_.XeroTooManyErrorInMinute) as e:
+        except (requests.HTTPError, client_.XeroTooManyInMinuteError) as e:
             pass
 
         self.assertEqual(mocked_failed_429_request_in_minute.call_count, 3)
@@ -518,7 +518,7 @@ class TestCheckPlatformAccessBehavior(unittest.TestCase):
 
         try:
             xero_client.check_platform_access(config, config_path)
-        except client_.XeroTooManyErrorInMinute as e:
+        except client_.XeroTooManyInMinuteError as e:
             expected_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded. Please retry after 5 seconds"
             self.assertEqual(str(e.message), expected_message)
 
@@ -559,7 +559,7 @@ class TestCheckPlatformAccessBehavior(unittest.TestCase):
 
         try:
             xero_client.check_platform_access(config, config_path)
-        except (requests.HTTPError, client_.XeroTooManyErrorInMinute) as e:
+        except (requests.HTTPError, client_.XeroTooManyInMinuteError) as e:
             pass
 
         self.assertEqual(mocked_failed_429_request_in_minute.call_count, 3)

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -76,15 +76,23 @@ def mocked_notfound_404_error(*args, **kwargs):
     return Mockresponse(json_decode_str, 404, raise_error=True)
 
 
+def mocked_precondition_failed_412_error(*args, **kwargs):
+    json_decode_str = {}
+
+    return Mockresponse(json_decode_str, 412, raise_error=True)
+
+
 def mocked_failed_429_request_in_day(*args, **kwargs):
     json_decode_str = ''
     headers = {"Retry-After": 1000, "X-Rate-Limit-Problem": "day"}
     return Mockresponse(json_decode_str, 429, headers=headers, raise_error=True)
 
+
 def mocked_failed_429_request_in_minute(*args, **kwargs):
     json_decode_str = ''
     headers = {"Retry-After": 5, "X-Rate-Limit-Problem": "minute"}
     return Mockresponse(json_decode_str, 429, headers=headers, raise_error=True)
+
 
 def mocked_internalservererror_500_error(*args, **kwargs):
     json_decode_str = {}
@@ -96,6 +104,12 @@ def mocked_notimplemented_501_error(*args, **kwargs):
     json_decode_str = {}
 
     return Mockresponse(json_decode_str, 501, raise_error=True)
+
+
+def mocked_not_available_503_error(*args, **kwargs):
+    json_decode_str = {}
+
+    return Mockresponse(json_decode_str, 503, raise_error=True)
 
 
 def mock_successful_request(*args, **kwargs):
@@ -177,7 +191,7 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 400, Error: A validation exception has occurred."
 
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e.message), expected_error_message)
+            self.assertEquals(str(e), expected_error_message)
             pass
 
 
@@ -196,7 +210,7 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 401, Error: Invalid authorization credentials."
 
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e.message), expected_error_message)
+            self.assertEquals(str(e), expected_error_message)
             pass
 
 
@@ -215,7 +229,7 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 403, Error: User doesn't have permission to access the resource."
 
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e.message), expected_error_message)
+            self.assertEquals(str(e), expected_error_message)
             pass
 
 
@@ -234,9 +248,26 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 404, Error: The resource you have specified cannot be found."
 
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e.message), expected_error_message)
+            self.assertEquals(str(e), expected_error_message)
             pass
 
+    @mock.patch('requests.Request', side_effect=mocked_precondition_failed_412_error)
+    def test_precondition_failed_412_error(self, mocked_session, mocked_precondition_failed_412_error):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.filter(tap_stream_id)
+        except client_.XeroPreConditionFailedError as e:
+            expected_error_message = "HTTP-error-code: 412, Error: One or more conditions given in the request header fields were invalid."
+
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            pass
 
     @mock.patch('requests.Request', side_effect=mocked_internalservererror_500_error)
     def test_internalservererror_500_error(self, mocked_session, mocked_internalservererror_500_error):
@@ -253,7 +284,7 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 500, Error: An unhandled error with the Xero API. Contact the Xero API team if problems persist."
 
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e.message), expected_error_message)
+            self.assertEquals(str(e), expected_error_message)
             pass
 
 
@@ -272,7 +303,25 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 501, Error: The method you have called has not been implemented."
 
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e.message), expected_error_message)
+            self.assertEquals(str(e), expected_error_message)
+            pass
+
+    @mock.patch('requests.Request', side_effect=mocked_not_available_503_error)
+    def test_not_available_503_error(self, mocked_session, mocked_not_available_503_error):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.filter(tap_stream_id)
+        except client_.XeroNotAvailableError as e:
+            expected_error_message = "HTTP-error-code: 503, Error: API service is currently unavailable."
+
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
             pass
 
 
@@ -292,7 +341,7 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded. Please retry after 1000 seconds"
             
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e.message), expected_error_message)
+            self.assertEquals(str(e), expected_error_message)
             pass
 
 
@@ -312,7 +361,7 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded. Please retry after 5 seconds"
             
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e.message), expected_error_message)
+            self.assertEquals(str(e), expected_error_message)
             pass
 
 
@@ -387,7 +436,7 @@ class TestCheckPlatformAccessBehavior(unittest.TestCase):
             xero_client.check_platform_access(config, config_path)
         except client_.XeroUnauthorizedError as e:
             expected_message = "HTTP-error-code: 401, Error: Invalid authorization credentials."
-            self.assertEqual(str(e.message) ,expected_message)
+            self.assertEqual(str(e) ,expected_message)
 
 
     @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
@@ -406,7 +455,7 @@ class TestCheckPlatformAccessBehavior(unittest.TestCase):
             xero_client.check_platform_access(config, config_path)
         except client_.XeroForbiddenError as e:
             expected_message = "HTTP-error-code: 403, Error: User doesn't have permission to access the resource."
-            self.assertEqual(str(e.message) ,expected_message)
+            self.assertEqual(str(e) ,expected_message)
 
 
     @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
@@ -425,7 +474,7 @@ class TestCheckPlatformAccessBehavior(unittest.TestCase):
             xero_client.check_platform_access(config, config_path)
         except client_.XeroBadRequestError as e:
             expected_message = "HTTP-error-code: 400, Error: A validation exception has occurred."
-            self.assertEqual(str(e.message), expected_message)
+            self.assertEqual(str(e), expected_message)
 
 
     @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
@@ -444,7 +493,26 @@ class TestCheckPlatformAccessBehavior(unittest.TestCase):
             xero_client.check_platform_access(config, config_path)
         except client_.XeroNotFoundError as e:
             expected_message = "HTTP-error-code: 404, Error: The resource you have specified cannot be found."
-            self.assertEqual(str(e.message), expected_message)
+            self.assertEqual(str(e), expected_message)
+
+
+    @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
+    @mock.patch('requests.Request', side_effect=mocked_precondition_failed_412_error)
+    def test_precondition_failed_412_error_in_discovery_mode(self, mocked_refresh_credentials, mocked_session, mocked_precondition_failed_412_error):
+        
+        mocked_refresh_credentials.return_value = ""
+        config = {}
+        config_path = ""
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.check_platform_access(config, config_path)
+        except client_.XeroPreConditionFailedError as e:
+            expected_message = "HTTP-error-code: 412, Error: One or more conditions given in the request header fields were invalid."
+            self.assertEqual(str(e), expected_message)
         
 
     @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
@@ -463,7 +531,7 @@ class TestCheckPlatformAccessBehavior(unittest.TestCase):
             xero_client.check_platform_access(config, config_path)
         except client_.XeroInternalError as e:
             expected_message = "HTTP-error-code: 500, Error: An unhandled error with the Xero API. Contact the Xero API team if problems persist."
-            self.assertEqual(str(e.message), expected_message)
+            self.assertEqual(str(e), expected_message)
 
 
     @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
@@ -482,7 +550,26 @@ class TestCheckPlatformAccessBehavior(unittest.TestCase):
             xero_client.check_platform_access(config, config_path)
         except client_.XeroNotImplementedError as e:
             expected_message = "HTTP-error-code: 501, Error: The method you have called has not been implemented."
-            self.assertEqual(str(e.message), expected_message)
+            self.assertEqual(str(e), expected_message)
+
+
+    @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
+    @mock.patch('requests.Request', side_effect=mocked_not_available_503_error)
+    def test_not_available_503_error_in_discovery_mode(self, mocked_refresh_credentials, mocked_session, mocked_not_available_503_error):
+        
+        mocked_refresh_credentials.return_value = ""
+        config = {}
+        config_path = ""
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.check_platform_access(config, config_path)
+        except client_.XeroNotAvailableError as e:
+            expected_message = "HTTP-error-code: 503, Error: API service is currently unavailable."
+            self.assertEqual(str(e), expected_message)
 
 
     @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
@@ -501,7 +588,7 @@ class TestCheckPlatformAccessBehavior(unittest.TestCase):
             xero_client.check_platform_access(config, config_path)
         except client_.XeroTooManyError as e:
             expected_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded. Please retry after 1000 seconds"
-            self.assertEqual(str(e.message), expected_message)
+            self.assertEqual(str(e), expected_message)
 
 
     @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
@@ -520,7 +607,7 @@ class TestCheckPlatformAccessBehavior(unittest.TestCase):
             xero_client.check_platform_access(config, config_path)
         except client_.XeroTooManyInMinuteError as e:
             expected_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded. Please retry after 5 seconds"
-            self.assertEqual(str(e.message), expected_message)
+            self.assertEqual(str(e), expected_message)
 
 
     @mock.patch("tap_xero.client.XeroClient.refresh_credentials")


### PR DESCRIPTION
# Description of change
- Added wait time with backoff for retry on 429 error code for minute limit.
- Added backoff mechanism for discover mode also.

# Manual QA steps
 - Raised 429 with a minute limit in a local environment and verified discover and sync mode if the function is retyring.
 - Verified normal scenario of status code 200.
 
# Risks
 - No risk found.
 
# Rollback steps
 - revert this branch
