### PR TITLE
TDL-16623: Request less data in check mode to verify credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-xero/bin/activate
-            pylint tap_xero --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace,unspecified-encoding'
+            pylint tap_xero --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace,unspecified-encoding,consider-using-f-string'
       - run:
           name: 'Unit Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,13 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-xero/bin/activate
-            nosetests tests/unittests/
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_xero --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
       - run:
           name: 'Integration Tests'
           command: |

--- a/tap_xero/client.py
+++ b/tap_xero/client.py
@@ -223,13 +223,13 @@ class XeroClient():
             "Xero-Tenant-Id": self.tenant_id,
             "Content-Type": "application/json"
         }
-        # Request for first page which returns first 100 contacts only
+        # Request for first page which returns first 100 invoices only
         params = {
             "page": 1
         }
         # Validating the authorization of the provided configuration
-        contacts_url = join(BASE_URL, "Contacts")
-        request = requests.Request("GET", contacts_url, headers=headers, params=params)
+        invoices_url = join(BASE_URL, "Invoices")
+        request = requests.Request("GET", invoices_url, headers=headers, params=params)
         response = self.session.send(request.prepare())
 
         if response.status_code != 200:

--- a/tap_xero/client.py
+++ b/tap_xero/client.py
@@ -223,10 +223,13 @@ class XeroClient():
             "Xero-Tenant-Id": self.tenant_id,
             "Content-Type": "application/json"
         }
-
+        # Request for first page which returns first 100 contacts only
+        params = {
+            "page": 1
+        }
         # Validating the authorization of the provided configuration
         contacts_url = join(BASE_URL, "Contacts")
-        request = requests.Request("GET", contacts_url, headers=headers)
+        request = requests.Request("GET", contacts_url, headers=headers, params=params)
         response = self.session.send(request.prepare())
 
         if response.status_code != 200:

--- a/tests/unittests/test_check_platform_access_request.py
+++ b/tests/unittests/test_check_platform_access_request.py
@@ -1,0 +1,31 @@
+import tap_xero.client as client_
+import unittest
+from unittest import mock
+from test_exception_handling import mocked_session, mock_successful_request, mock_successful_session_post
+
+@mock.patch('requests.Session.send', side_effect=mocked_session)
+class TestCheckPlatformAccessRequest(unittest.TestCase):
+
+    @mock.patch('requests.Session.post', side_effect=mock_successful_session_post)
+    @mock.patch('tap_xero.client.update_config_file')
+    @mock.patch('requests.Request', side_effect=mock_successful_request)
+    def test_check_platform_access_request(self, mocked_request, mocked_update_config_file, mocked_post, mocked_send):
+        '''
+            Verify that check_platform_access called with expected endpoint and paramater for validating credentials
+        '''
+        config = {
+            "client_id": "123",
+            "client_secret": "123",
+            "refresh_token": "123",
+            "tenant_id": "123"
+        }
+
+        # Initialize XeroClient and call check_platform_access function
+        xero_client = client_.XeroClient(config)
+        xero_client.check_platform_access(config, "")
+        
+        # Verify requests.request is called with expected endpoint(Invoice) and parmeter in check_platform_access
+        mocked_request.assert_called_with('GET',
+                                       'https://api.xero.com/api.xro/2.0/Invoices',
+                                        headers={'Authorization': 'Bearer 123', 'Xero-Tenant-Id': '123', 'Content-Type': 'application/json'},
+                                        params={'page': 1})


### PR DESCRIPTION
# Description of change
[TDl-16623](https://jira.talendforge.org/browse/TDL-16623): Use a stream other than Contacts or ask for fewer data to check for authentication
- Changed endpoint to invoices and added page parameter to request first 100 invoices only to verify credentials in discover mode.

NOTE: Disabled consider-using-f-string in pylint but build is still failing because the token is expired on the circleci side

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
