### PR TITLE
Remove `order` query param from manual_journals request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.3
+  * Adds a workaround for a Xero bug to allow pagination to function properly in the `manual_journals` stream [#104](https://github.com/singer-io/tap-xero/pull/104)
+
 ## 2.2.2
   * Changes the endpoint used for check_platform_access from `Contacts` to `Currencies` [#98](https://github.com/singer-io/tap-xero/pull/98)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-xero",
-      version="2.2.2",
+      version="2.2.3",
       description="Singer.io tap for extracting data from the Xero API",
       author="Stitch",
       url="http://singer.io",

--- a/tap_xero/streams.py
+++ b/tap_xero/streams.py
@@ -78,7 +78,7 @@ class BookmarkedStream(Stream):
         if records:
             self.format_fn(records)
             self.write_records(records, ctx)
-            max_bookmark_value = max([record[self.bookmark_key] for record in records])
+            max_bookmark_value = max([record[self.bookmark_key] for record in records]) # pylint: disable=consider-using-generator
             ctx.set_bookmark(bookmark, max_bookmark_value)
             ctx.write_state()
 

--- a/tap_xero/streams.py
+++ b/tap_xero/streams.py
@@ -93,7 +93,13 @@ class PaginatedStream(Stream):
         start = ctx.update_start_date_bookmark(bookmark)
         curr_page_num = ctx.get_offset(offset) or 1
 
-        self.filter_options.update(dict(since=start, order="UpdatedDateUTC ASC"))
+        self.filter_options.update({"since": start})
+
+        # Xero bug causes all manual_journal records to be returned instead of
+        # 100 per page when `order` is specified. `UpdatedDateUTC ASC` is the
+        # default so we can safely exclude it until the bug is fixed.
+        if self.tap_stream_id != "manual_journals":
+            self.filter_options.update({"order": "UpdatedDateUTC ASC"})
 
         max_updated = start
         while True:


### PR DESCRIPTION
# Description of change
The Xero API currently has a bug where **all** manual journal records created or modified since the last bookmark are returned instead of 100 per page. Xero support noticed this only happens when `order` is added as a query parameter in the request.

The tap pages through results until the response has fewer than 100 records, as recommended by Xero. The bug was causing the paging logic to loop until the API quota was exceeded when there were 100+ manual journal records in the response.

This temporary fix removes the `order` query parameter when retrieving data for the manual_journals stream until Xero fixes the bug. It was previously `order=UpdatedDateUTC ASC`. [Xero's docs](https://developer.xero.com/documentation/api/accounting/manualjournals#get-manualjournals) say "The default order is UpdatedDateUTC ASC" so the response will still have the data in the expected order.

# Manual QA steps
 - Created 150 manual journal entries
 - Verified paging works as expected
 - Verified the order is still UpdatedDateUTC ASC
 
# Risks
 - Xero changes their default to something other than `order=UpdatedDateUTC ASC`.
 
# Rollback steps
 - revert this branch
