### PR TITLE
Revert "Bump requests from 2.20.0 to 2.31.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## 2.2.4
-  * Dependabot update [#105](https://github.com/singer-io/tap-xero/pull/105)
-
 ## 2.2.3
   * Adds a workaround for a Xero bug to allow pagination to function properly in the `manual_journals` stream [#104](https://github.com/singer-io/tap-xero/pull/104)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-xero",
-      version="2.2.4",
+      version="2.2.3",
       description="Singer.io tap for extracting data from the Xero API",
       author="Stitch",
       url="http://singer.io",
@@ -10,7 +10,7 @@ setup(name="tap-xero",
       py_modules=["tap_xero"],
       install_requires=[
           "singer-python==5.9.0",
-          "requests==2.31.0",
+          "requests==2.20.0",
       ],
       extras_require={
           'dev': [


### PR DESCRIPTION
Reverts singer-io/tap-xero#105, python version needs to be updated before requests can be bumped