### PR TITLE
update singer python version for clear_offset fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,9 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            uv venv --python 3.9 /usr/local/share/virtualenvs/tap-xero
+            uv venv --python 3.12 /usr/local/share/virtualenvs/tap-xero
             source /usr/local/share/virtualenvs/tap-xero/bin/activate
-            uv pip install -U 'pip<19.2' 'setuptools<51.0.0'
+            uv pip install -U 'pip' 'setuptools'
             uv pip install .[dev]
       - run:
           name: 'JSON Validator'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4.0
+  * Bump singer-python version [#127](https://github.com/singer-io/tap-xero/pull/127)
+
 ## 2.3.2
   * Bump dependency versions for twistlock compliance [#122](https://github.com/singer-io/tap-xero/pull/122)
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(name="tap-xero",
       install_requires=[
           "singer-python==5.18.0",
           "requests==2.32.5",
-          "urllib3==2.6.3",
       ],
       extras_require={
           'dev': [

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name="tap-xero",
       py_modules=["tap_xero"],
       install_requires=[
           "singer-python==5.18.0",
-          "requests==2.32.4",
+          "requests==2.32.5",
       ],
       extras_require={
           'dev': [

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name="tap-xero",
       classifiers=["Programming Language :: Python :: 3 :: Only"],
       py_modules=["tap_xero"],
       install_requires=[
-          "singer-python==5.13.2",
+          "singer-python==5.18.0",
           "requests==2.32.4",
       ],
       extras_require={

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-xero",
-      version="2.3.2",
+      version="2.4.0",
       description="Singer.io tap for extracting data from the Xero API",
       author="Stitch",
       url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(name="tap-xero",
       install_requires=[
           "singer-python==5.18.0",
           "requests==2.32.5",
+          "urllib3==2.6.3",
       ],
       extras_require={
           'dev': [

--- a/tap_xero/context.py
+++ b/tap_xero/context.py
@@ -1,5 +1,5 @@
 import singer
-from singer import bookmarks as bks_
+from singer import state as st_
 from .client import XeroClient
 
 
@@ -18,20 +18,20 @@ class Context():
         self.client.check_platform_access(self.config, self.config_path)
 
     def get_bookmark(self, path):
-        return bks_.get_bookmark(self.state, *path)
+        return st_.get_bookmark(self.state, *path)
 
     def set_bookmark(self, path, val):
-        bks_.write_bookmark(self.state, path[0], path[1], val)
+        st_.set_bookmark(self.state, path[0], path[1], val)
 
     def get_offset(self, path):
-        off = bks_.get_offset(self.state, path[0])
+        off = st_.get_offset(self.state, path[0])
         return (off or {}).get(path[1])
 
     def set_offset(self, path, val):
-        bks_.set_offset(self.state, path[0], path[1], val)
+        st_.set_offset(self.state, path[0], path[1], val)
 
     def clear_offsets(self, tap_stream_id):
-        bks_.clear_offset(self.state, tap_stream_id)
+        st_.clear_offset(self.state, tap_stream_id)
 
     def update_start_date_bookmark(self, path):
         val = self.get_bookmark(path)


### PR DESCRIPTION
# Description of change
Updates singer-python version to `5.18.0` to use `clear_offset` fix which pops the key from the bookmark instead of setting it to empty map. 

# Manual QA steps
 - Ran xero connection locally, verified state after update. 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
