### PR TITLE
Fail connection for deprecated streams

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             uv pip install --upgrade awscli
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/vm dev_env.sh
             source dev_env.sh
             run-test --tap=tap-xero tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             uv pip install --upgrade awscli
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/vm dev_env.sh
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             run-test --tap=tap-xero tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.5.0
+  * Fail connection for deprecated streams [#128](https://github.com/singer-io/tap-xero/pull/128)
+
 ## 2.4.0
   * Bump singer-python version [#127](https://github.com/singer-io/tap-xero/pull/127)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-xero",
-      version="2.4.0",
+      version="2.5.0",
       description="Singer.io tap for extracting data from the Xero API",
       author="Stitch",
       url="http://singer.io",

--- a/tap_xero/__init__.py
+++ b/tap_xero/__init__.py
@@ -116,16 +116,17 @@ def sync(ctx):
         stream.sync(ctx)
     ctx.state["currently_syncing"] = None
     ctx.write_state()
-    selected_deprecated = [s for s in stream_ids_to_sync if s in DEPRECATED_STREAM_IDS]
-    if selected_deprecated:
-        LOGGER.warning(
-            "WARNING: The following selected streams are deprecated by Xero and will be removed "
-            "after 28th April 2026: %s. These streams may stop returning data or cause sync "
-            "failures at any time. Please deselect them and consider using the Invoices stream "
-            "as a replacement for Expense Claims and Receipts. "
-            "See: https://developer.xero.com/documentation/api/accounting/overview for details.",
-            ", ".join(selected_deprecated)
-        )
+    for stream_id in stream_ids_to_sync:
+        if stream_id in DEPRECATED_STREAM_IDS:
+            raise Exception(
+                "The following streams are deprecated and will be removed on 28th April 2026: "
+                "Employees, Expense Claims, and Receipts. Please deselect these streams to avoid sync errors. "
+                "Consider using the Invoices stream as a replacement for Expense Claims and Receipts. "
+                "For more details, see the Xero API documentation: "
+                "https://developer.xero.com/documentation/api/accounting/receipts, "
+                "https://developer.xero.com/documentation/api/accounting/employees, "
+                "https://developer.xero.com/documentation/api/accounting/expenseclaims"
+            )
 
 
 def main_impl():

--- a/tap_xero/__init__.py
+++ b/tap_xero/__init__.py
@@ -19,6 +19,12 @@ REQUIRED_CONFIG_KEYS = [
 
 LOGGER = singer.get_logger()
 
+DEPRECATED_STREAM_IDS = [
+    "expense_claims",
+    "employees",
+    "receipts",
+]
+
 BAD_CREDS_MESSAGE = (
     "Failed to refresh OAuth token using the credentials from both the config and S3. "
     "The token might need to be reauthorized from the integration's properties "
@@ -110,7 +116,16 @@ def sync(ctx):
         stream.sync(ctx)
     ctx.state["currently_syncing"] = None
     ctx.write_state()
-
+    selected_deprecated = [s for s in stream_ids_to_sync if s in DEPRECATED_STREAM_IDS]
+    if selected_deprecated:
+        LOGGER.warning(
+            "WARNING: The following selected streams are deprecated by Xero and will be removed "
+            "after 28th April 2026: %s. These streams may stop returning data or cause sync "
+            "failures at any time. Please deselect them and consider using the Invoices stream "
+            "as a replacement for Expense Claims and Receipts. "
+            "See: https://developer.xero.com/documentation/api/accounting/overview for details.",
+            ", ".join(selected_deprecated)
+        )
 
 
 def main_impl():

--- a/tap_xero/__init__.py
+++ b/tap_xero/__init__.py
@@ -119,8 +119,9 @@ def sync(ctx):
     for stream_id in stream_ids_to_sync:
         if stream_id in DEPRECATED_STREAM_IDS:
             raise Exception(
-                "The following streams are deprecated and will be removed on 28th April 2026: "
-                "Employees, Expense Claims, and Receipts. Please deselect these streams to avoid sync errors. "
+                "Employees, Expense Claims, and Receipts endpoints are deprecated and associated streams "
+                "`employees`, `expense_claims` and `receipts` will be removed on 28th April 2026. "
+                "Please deselect these streams to avoid sync errors. "
                 "Consider using the Invoices stream as a replacement for Expense Claims and Receipts. "
                 "For more details, see the Xero API documentation: "
                 "https://developer.xero.com/documentation/api/accounting/receipts, "

--- a/tests/base.py
+++ b/tests/base.py
@@ -34,7 +34,7 @@ class XeroScenarioBase(unittest.TestCase):
             missing_envs = missing_creds + missing_props
             raise Exception("set " + ", ".join(missing_envs))
         self._credentials = {k: os.getenv(v) for k, v in required_creds.items()}
-        self.conn_id = connections.ensure_connection(self, payload_hook=preserve_refresh_token)
+        self.conn_id = connections.ensure_connection(self)
 
     def get_type(self):
         return "platform.xero"

--- a/tests/base.py
+++ b/tests/base.py
@@ -34,7 +34,7 @@ class XeroScenarioBase(unittest.TestCase):
             missing_envs = missing_creds + missing_props
             raise Exception("set " + ", ".join(missing_envs))
         self._credentials = {k: os.getenv(v) for k, v in required_creds.items()}
-        self.conn_id = connections.ensure_connection(self)
+        self.conn_id = connections.ensure_connection(self, payload_hook=preserve_refresh_token)
 
     def get_type(self):
         return "platform.xero"

--- a/tests/base.py
+++ b/tests/base.py
@@ -92,14 +92,10 @@ class XeroScenarioBase(unittest.TestCase):
             "overpayments": ["UpdatedDateUTC"],
             "prepayments": ["UpdatedDateUTC"],
             "purchase_orders": ["UpdatedDateUTC"],
-            "journals": ["JournalNumber"],
             "accounts": ["UpdatedDateUTC"],
             "bank_transfers": ["CreatedDateUTC"],
-            "employees": ["UpdatedDateUTC"],
-            "expense_claims": ["UpdatedDateUTC"],
             "items": ["UpdatedDateUTC"],
             "payments": ["UpdatedDateUTC"],
-            "receipts": ["UpdatedDateUTC"],
             "users": ["UpdatedDateUTC"],
             "linked_transactions": ["UpdatedDateUTC"],
             "quotes": ["UpdatedDateUTC"]
@@ -164,6 +160,8 @@ class XeroScenarioBase(unittest.TestCase):
         # menagerie.post_annotated_catalogs(self.conn_id, selected)
         for catalog in found_catalogs:
             schema = menagerie.get_annotated_schema(self.conn_id, catalog['stream_id'])
+            if catalog['tap_stream_id'] in ["journals", "expense_claims", "receipts", "employees"]:
+                continue
             non_selected_properties = []
             additional_md = []
 

--- a/tests/test_xero_bookmarks.py
+++ b/tests/test_xero_bookmarks.py
@@ -47,7 +47,7 @@ class XeroBookmarks(XeroScenarioBase):
     def check_offsets(self, bookmarks):
         for stream, offset in self.expected_offsets.items():
             self.assertEqual(
-                bookmarks.get(stream, {}).get("offset"), offset,
+                bookmarks.get(stream, {}).get("offset", {}), offset,
                 msg=("unexpected offset found for stream {} {}. bookmarks: {}"
                      .format(stream, offset, bookmarks))
             )

--- a/tests/test_xero_future_dates_no_data.py
+++ b/tests/test_xero_future_dates_no_data.py
@@ -25,7 +25,6 @@ class XeroFutureDatesNoData(XeroScenarioBase):
                 "overpayments": {"UpdatedDateUTC": future_date},
                 "prepayments": {"UpdatedDateUTC": future_date},
                 "purchase_orders": {"UpdatedDateUTC": future_date},
-                "journals": {"JournalNumber": 10e10},
                 "accounts": {"UpdatedDateUTC": future_date},
                 "bank_transfers": {"CreatedDateUTC": future_date},
                 "employees": {"UpdatedDateUTC": future_date},

--- a/tests/unittests/test_datetime_parsing.py
+++ b/tests/unittests/test_datetime_parsing.py
@@ -20,7 +20,7 @@ class TestDatetimeParsing(unittest.TestCase):
             strptime_to_utc('2020-01-01T12:30:00+0'),
         ]
 
-        self.assertEquals(parsed_dates, expected_dates)
+        self.assertEqual(parsed_dates, expected_dates)
 
     def test_epoch_datetimes(self):
         dates = [
@@ -39,7 +39,7 @@ class TestDatetimeParsing(unittest.TestCase):
             datetime.datetime(1920, 5, 23, 00, 00, 00),
         ]
 
-        self.assertEquals(parsed_dates, expected_dates)
+        self.assertEqual(parsed_dates, expected_dates)
 
     def test_not_datetimes(self):
         dates = [
@@ -53,4 +53,4 @@ class TestDatetimeParsing(unittest.TestCase):
 
         expected_dates = [None, None, None, None]
 
-        self.assertEquals(parsed_dates, expected_dates)
+        self.assertEqual(parsed_dates, expected_dates)

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -191,7 +191,7 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 400, Error: A validation exception has occurred."
 
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
+            self.assertEqual(str(e), expected_error_message)
             pass
 
 
@@ -210,7 +210,7 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 401, Error: Invalid authorization credentials."
 
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
+            self.assertEqual(str(e), expected_error_message)
             pass
 
 
@@ -229,7 +229,7 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 403, Error: User doesn't have permission to access the resource."
 
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
+            self.assertEqual(str(e), expected_error_message)
             pass
 
 
@@ -248,7 +248,7 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 404, Error: The resource you have specified cannot be found."
 
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
+            self.assertEqual(str(e), expected_error_message)
             pass
 
     @mock.patch('requests.Request', side_effect=mocked_precondition_failed_412_error)
@@ -266,7 +266,7 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 412, Error: One or more conditions given in the request header fields were invalid."
 
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
+            self.assertEqual(str(e), expected_error_message)
             pass
 
     @mock.patch('requests.Request', side_effect=mocked_internalservererror_500_error)
@@ -284,7 +284,7 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 500, Error: An unhandled error with the Xero API. Contact the Xero API team if problems persist."
 
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
+            self.assertEqual(str(e), expected_error_message)
             pass
 
 
@@ -303,7 +303,7 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 501, Error: The method you have called has not been implemented."
 
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
+            self.assertEqual(str(e), expected_error_message)
             pass
 
     @mock.patch('requests.Request', side_effect=mocked_not_available_503_error)
@@ -321,7 +321,7 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 503, Error: API service is currently unavailable."
 
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
+            self.assertEqual(str(e), expected_error_message)
             pass
 
 
@@ -341,7 +341,7 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded. Please retry after 1000 seconds"
             
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
+            self.assertEqual(str(e), expected_error_message)
             pass
 
 
@@ -361,7 +361,7 @@ class TestFilterFunExceptionHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded. Please retry after 5 seconds"
             
             # Verifying the message formed for the custom exception
-            self.assertEquals(str(e), expected_error_message)
+            self.assertEqual(str(e), expected_error_message)
             pass
 
 


### PR DESCRIPTION
# Description of change
-  The following streams are going to be removed on 28th April 2026.
 - [Employees](https://developer.xero.com/documentation/api/accounting/employees)
 - [Expense Claims](https://developer.xero.com/documentation/api/accounting/expenseclaims)
 - [Receipts](https://developer.xero.com/documentation/api/accounting/receipts)
 
- Fail connection if any of the above streams are selected.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
